### PR TITLE
add kubernetes-mixin dashboards for grafana using k8s-sidecar #2

### DIFF
--- a/apply.sh
+++ b/apply.sh
@@ -7,6 +7,7 @@ DEPLOYDIR="deploy"
 kubectl apply -f $DEPLOYDIR/namespaces.yaml
 kubectl apply -f $DEPLOYDIR/prometheus/setup/
 kubectl apply -f $DEPLOYDIR/prometheus/
+kubectl apply -f $DEPLOYDIR/dashboards/
 kubectl apply -f $DEPLOYDIR/loki-manifests.yaml
 kubectl apply -f $DEPLOYDIR/promtail-manifests.yaml
 kubectl apply -f $DEPLOYDIR/tempo-manifests.yaml

--- a/build.sh
+++ b/build.sh
@@ -16,3 +16,5 @@ helm template --release-name tempo --namespace tracing -f grafana/tempo/values.y
 kustomize build grafana/tempo/ > $DEPLOYDIR/tempo-manifests.yaml
 ./kube-prometheus/build.sh
 cp -r kube-prometheus/manifests-example.local $DEPLOYDIR/prometheus
+mkdir -p $DEPLOYDIR/dashboards
+mv kube-prometheus/dashboards/*.yaml $DEPLOYDIR/dashboards

--- a/deploy/dashboards/apiserver.yaml
+++ b/deploy/dashboards/apiserver.yaml
@@ -1,0 +1,1548 @@
+apiVersion: v1
+data:
+  apiserver.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": false,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "id": null,
+       "links": [ ],
+       "panels": [
+          {
+             "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only.",
+             "datasource": null,
+             "description": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only.",
+             "gridPos": {
+                "h": 2,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 2,
+             "mode": "markdown",
+             "span": 12,
+             "title": "Notice",
+             "type": "text"
+          }
+       ],
+       "refresh": "10s",
+       "rows": [
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                   ],
+                   "datasource": "$datasource",
+                   "decimals": 3,
+                   "description": "How many percent of requests (both read and write) in 30 days have been answered successfully and fast enough?",
+                   "format": "percentunit",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": false,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 3,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 4,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "apiserver_request:availability30d{verb=\"all\", cluster=\"$cluster\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "",
+                   "title": "Availability (30d) > 99.000%",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "avg"
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "decimals": 3,
+                   "description": "How much error budget is left looking at our 0.990% availability guarantees?",
+                   "fill": 10,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 4,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 8,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "100 * (apiserver_request:availability30d{verb=\"all\", cluster=\"$cluster\"} - 0.990000)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "errorbudget",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "ErrorBudget (30d) > 99.000%",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "decimals": 3,
+                         "format": "percentunit",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "decimals": 3,
+                         "format": "percentunit",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                   ],
+                   "datasource": "$datasource",
+                   "decimals": 3,
+                   "description": "How many percent of read requests (LIST,GET) in 30 days have been answered successfully and fast enough?",
+                   "format": "percentunit",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": false,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 5,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 3,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "apiserver_request:availability30d{verb=\"read\", cluster=\"$cluster\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "",
+                   "title": "Read Availability (30d)",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "avg"
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "description": "How many read requests (LIST,GET) per second do the apiservers get by code?",
+                   "fill": 10,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 6,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [
+                      {
+                         "alias": "/2../i",
+                         "color": "#56A64B"
+                      },
+                      {
+                         "alias": "/3../i",
+                         "color": "#F2CC0C"
+                      },
+                      {
+                         "alias": "/4../i",
+                         "color": "#3274D9"
+                      },
+                      {
+                         "alias": "/5../i",
+                         "color": "#E02F44"
+                      }
+                   ],
+                   "spaceLength": 10,
+                   "span": 3,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"read\", cluster=\"$cluster\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{ code }}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Read SLI - Requests",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "reqps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "reqps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "description": "How many percent of read requests (LIST,GET) per second are returned with errors (5xx)?",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 7,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 3,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"read\",code=~\"5..\", cluster=\"$cluster\"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"read\", cluster=\"$cluster\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{ resource }}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Read SLI - Errors",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "percentunit",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "percentunit",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "description": "How many seconds is the 99th percentile for reading (LIST|GET) a given resource?",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 8,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 3,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{verb=\"read\", cluster=\"$cluster\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{ resource }}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Read SLI - Duration",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                   ],
+                   "datasource": "$datasource",
+                   "decimals": 3,
+                   "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) in 30 days have been answered successfully and fast enough?",
+                   "format": "percentunit",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": false,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 9,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 3,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "apiserver_request:availability30d{verb=\"write\", cluster=\"$cluster\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "",
+                   "title": "Write Availability (30d)",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "avg"
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "description": "How many write requests (POST|PUT|PATCH|DELETE) per second do the apiservers get by code?",
+                   "fill": 10,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 10,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [
+                      {
+                         "alias": "/2../i",
+                         "color": "#56A64B"
+                      },
+                      {
+                         "alias": "/3../i",
+                         "color": "#F2CC0C"
+                      },
+                      {
+                         "alias": "/4../i",
+                         "color": "#3274D9"
+                      },
+                      {
+                         "alias": "/5../i",
+                         "color": "#E02F44"
+                      }
+                   ],
+                   "spaceLength": 10,
+                   "span": 3,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"write\", cluster=\"$cluster\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{ code }}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Write SLI - Requests",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "reqps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "reqps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) per second are returned with errors (5xx)?",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 11,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 3,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"write\",code=~\"5..\", cluster=\"$cluster\"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"write\", cluster=\"$cluster\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{ resource }}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Write SLI - Errors",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "percentunit",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "percentunit",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "description": "How many seconds is the 99th percentile for writing (POST|PUT|PATCH|DELETE) a given resource?",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 12,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 3,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{verb=\"write\", cluster=\"$cluster\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{ resource }}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Write SLI - Duration",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 13,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": false,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(workqueue_adds_total{job=\"kube-apiserver\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{name}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Work Queue Add Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 14,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": false,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(workqueue_depth{job=\"kube-apiserver\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{name}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Work Queue Depth",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 15,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{job=\"kube-apiserver\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{name}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Work Queue Latency",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 16,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "process_resident_memory_bytes{job=\"kube-apiserver\",instance=~\"$instance\", cluster=\"$cluster\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 17,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "rate(process_cpu_seconds_total{job=\"kube-apiserver\",instance=~\"$instance\", cluster=\"$cluster\"}[5m])",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 18,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "go_goroutines{job=\"kube-apiserver\",instance=~\"$instance\", cluster=\"$cluster\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Goroutines",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          }
+       ],
+       "schemaVersion": 14,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(apiserver_request_total, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "instance",
+                "options": [ ],
+                "query": "label_values(apiserver_request_total{job=\"kube-apiserver\", cluster=\"$cluster\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / API server",
+       "uid": "09ec8aa1e996d6ffcd6817bbaff4db1b",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: apiserver
+  namespace: default

--- a/deploy/dashboards/cluster-total.yaml
+++ b/deploy/dashboards/cluster-total.yaml
@@ -1,0 +1,1695 @@
+apiVersion: v1
+data:
+  cluster-total.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [
+             {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+             }
+          ]
+       },
+       "editable": true,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "id": null,
+       "links": [ ],
+       "panels": [
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 2,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Current Bandwidth",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "aliasColors": { },
+             "bars": true,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 1
+             },
+             "id": 3,
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": false,
+             "linewidth": 1,
+             "links": [ ],
+             "minSpan": 24,
+             "nullPointMode": "null",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 24,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{namespace}}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Rate of Bytes Received",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "series",
+                "name": null,
+                "show": false,
+                "values": [
+                   "current"
+                ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": true,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 1
+             },
+             "id": 4,
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": false,
+             "linewidth": 1,
+             "links": [ ],
+             "minSpan": 24,
+             "nullPointMode": "null",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 24,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{namespace}}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Rate of Bytes Transmitted",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "series",
+                "name": null,
+                "show": false,
+                "values": [
+                   "current"
+                ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "columns": [
+                {
+                   "text": "Time",
+                   "value": "Time"
+                },
+                {
+                   "text": "Value #A",
+                   "value": "Value #A"
+                },
+                {
+                   "text": "Value #B",
+                   "value": "Value #B"
+                },
+                {
+                   "text": "Value #C",
+                   "value": "Value #C"
+                },
+                {
+                   "text": "Value #D",
+                   "value": "Value #D"
+                },
+                {
+                   "text": "Value #E",
+                   "value": "Value #E"
+                },
+                {
+                   "text": "Value #F",
+                   "value": "Value #F"
+                },
+                {
+                   "text": "Value #G",
+                   "value": "Value #G"
+                },
+                {
+                   "text": "Value #H",
+                   "value": "Value #H"
+                },
+                {
+                   "text": "namespace",
+                   "value": "namespace"
+                }
+             ],
+             "datasource": "$datasource",
+             "fill": 1,
+             "fontSize": "90%",
+             "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 10
+             },
+             "id": 5,
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "minSpan": 24,
+             "nullPointMode": "null as zero",
+             "renderer": "flot",
+             "scroll": true,
+             "showHeader": true,
+             "sort": {
+                "col": 0,
+                "desc": false
+             },
+             "spaceLength": 10,
+             "span": 24,
+             "styles": [
+                {
+                   "alias": "Time",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Time",
+                   "thresholds": [ ],
+                   "type": "hidden",
+                   "unit": "short"
+                },
+                {
+                   "alias": "Current Bandwidth Received",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #A",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "Bps"
+                },
+                {
+                   "alias": "Current Bandwidth Transmitted",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #B",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "Bps"
+                },
+                {
+                   "alias": "Average Bandwidth Received",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #C",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "Bps"
+                },
+                {
+                   "alias": "Average Bandwidth Transmitted",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #D",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "Bps"
+                },
+                {
+                   "alias": "Rate of Received Packets",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #E",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "pps"
+                },
+                {
+                   "alias": "Rate of Transmitted Packets",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #F",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "pps"
+                },
+                {
+                   "alias": "Rate of Received Packets Dropped",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #G",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "pps"
+                },
+                {
+                   "alias": "Rate of Transmitted Packets Dropped",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #H",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "pps"
+                },
+                {
+                   "alias": "Namespace",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": true,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "d/8b7a8b326d7a6f1f04244066368c67af/kubernetes-networking-namespace-pods?orgId=1&refresh=30s&var-namespace=$__cell",
+                   "pattern": "namespace",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "short"
+                }
+             ],
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "A",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "B",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "C",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "D",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "E",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "F",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "G",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "H",
+                   "step": 10
+                }
+             ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Status",
+             "type": "table"
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 10
+             },
+             "id": 6,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": true,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 0,
+                      "y": 11
+                   },
+                   "id": 7,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "sort": "current",
+                      "sortDesc": true,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": false,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "minSpan": 24,
+                   "nullPointMode": "null",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 24,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{namespace}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Average Rate of Bytes Received",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "series",
+                      "name": null,
+                      "show": false,
+                      "values": [
+                         "current"
+                      ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": true,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 12,
+                      "y": 11
+                   },
+                   "id": 8,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "sort": "current",
+                      "sortDesc": true,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": false,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "minSpan": 24,
+                   "nullPointMode": "null",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 24,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{namespace}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Average Rate of Bytes Transmitted",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "series",
+                      "name": null,
+                      "show": false,
+                      "values": [
+                         "current"
+                      ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Average Bandwidth",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 11
+             },
+             "id": 9,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Bandwidth History",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 12
+             },
+             "id": 10,
+             "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": true,
+                "min": true,
+                "rightSide": true,
+                "show": true,
+                "sideWidth": null,
+                "total": false,
+                "values": true
+             },
+             "lines": true,
+             "linewidth": 2,
+             "links": [ ],
+             "minSpan": 24,
+             "nullPointMode": "connected",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 24,
+             "stack": true,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{namespace}}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Receive Bandwidth",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 21
+             },
+             "id": 11,
+             "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": true,
+                "min": true,
+                "rightSide": true,
+                "show": true,
+                "sideWidth": null,
+                "total": false,
+                "values": true
+             },
+             "lines": true,
+             "linewidth": 2,
+             "links": [ ],
+             "minSpan": 24,
+             "nullPointMode": "connected",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 24,
+             "stack": true,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{namespace}}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Transmit Bandwidth",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 30
+             },
+             "id": 12,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 24,
+                      "x": 0,
+                      "y": 31
+                   },
+                   "id": 13,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": true,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": true,
+                      "min": true,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 24,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 24,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{namespace}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 24,
+                      "x": 0,
+                      "y": 40
+                   },
+                   "id": 14,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": true,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": true,
+                      "min": true,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 24,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 24,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{namespace}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Packets",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 31
+             },
+             "id": 15,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 24,
+                      "x": 0,
+                      "y": 50
+                   },
+                   "id": 16,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": true,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": true,
+                      "min": true,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 24,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 24,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{namespace}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets Dropped",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 24,
+                      "x": 0,
+                      "y": 59
+                   },
+                   "id": 17,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": true,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": true,
+                      "min": true,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 24,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 24,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\".+\"}[$interval:$resolution])) by (namespace))",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{namespace}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets Dropped",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 24,
+                      "x": 0,
+                      "y": 59
+                   },
+                   "id": 18,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": true,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": true,
+                      "min": true,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [
+                      {
+                         "targetBlank": true,
+                         "title": "What is TCP Retransmit?",
+                         "url": "https://accedian.com/enterprises/blog/network-packet-loss-retransmissions-and-duplicate-acknowledgements/"
+                      }
+                   ],
+                   "minSpan": 24,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 24,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(rate(node_netstat_Tcp_RetransSegs{cluster=\"$cluster\"}[$interval:$resolution]) / rate(node_netstat_Tcp_OutSegs{cluster=\"$cluster\"}[$interval:$resolution])) by (instance))",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of TCP Retransmits out of all sent segments",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "percentunit",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "percentunit",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 24,
+                      "x": 0,
+                      "y": 59
+                   },
+                   "id": 19,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": true,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": true,
+                      "min": true,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [
+                      {
+                         "targetBlank": true,
+                         "title": "Why monitor SYN retransmits?",
+                         "url": "https://github.com/prometheus/node_exporter/issues/1023#issuecomment-408128365"
+                      }
+                   ],
+                   "minSpan": 24,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 24,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(rate(node_netstat_TcpExt_TCPSynRetrans{cluster=\"$cluster\"}[$interval:$resolution]) / rate(node_netstat_Tcp_RetransSegs{cluster=\"$cluster\"}[$interval:$resolution])) by (instance))",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of TCP SYN Retransmits out of all retransmits",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "percentunit",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "percentunit",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Errors",
+             "titleSize": "h6",
+             "type": "row"
+          }
+       ],
+       "refresh": "10s",
+       "rows": [ ],
+       "schemaVersion": 18,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "5m",
+                   "value": "5m"
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "resolution",
+                "options": [
+                   {
+                      "selected": false,
+                      "text": "30s",
+                      "value": "30s"
+                   },
+                   {
+                      "selected": true,
+                      "text": "5m",
+                      "value": "5m"
+                   },
+                   {
+                      "selected": false,
+                      "text": "1h",
+                      "value": "1h"
+                   }
+                ],
+                "query": "30s,5m,1h",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "interval",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "5m",
+                   "value": "5m"
+                },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "interval",
+                "options": [
+                   {
+                      "selected": true,
+                      "text": "4h",
+                      "value": "4h"
+                   }
+                ],
+                "query": "4h",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "interval",
+                "useTags": false
+             },
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Networking / Cluster",
+       "uid": "ff635a025bcfea7bc3dd4f508990a3e9",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: cluster-total
+  namespace: default

--- a/deploy/dashboards/controller-manager.yaml
+++ b/deploy/dashboards/controller-manager.yaml
@@ -1,0 +1,1030 @@
+apiVersion: v1
+data:
+  controller-manager.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": false,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "id": null,
+       "links": [ ],
+       "refresh": "10s",
+       "rows": [
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                   ],
+                   "datasource": "$datasource",
+                   "format": "none",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": false,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 2,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 2,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "sum(up{cluster=\"$cluster\", job=\"kube-controller-manager\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "",
+                   "title": "Up",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "min"
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 3,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 10,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(workqueue_adds_total{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (instance, name)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{name}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Work Queue Add Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 4,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(workqueue_depth{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (instance, name)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{name}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Work Queue Depth",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 5,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[5m])) by (instance, name, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{name}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Work Queue Latency",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 6,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "2xx",
+                         "refId": "A"
+                      },
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "3xx",
+                         "refId": "B"
+                      },
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "4xx",
+                         "refId": "C"
+                      },
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "5xx",
+                         "refId": "D"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Kube API Request Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 7,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 8,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{verb}} {{url}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Post Request Latency 99th Quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 8,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{verb}} {{url}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Get Request Latency 99th Quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 9,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 10,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}[5m])",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 11,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "go_goroutines{cluster=\"$cluster\", job=\"kube-controller-manager\",instance=~\"$instance\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Goroutines",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          }
+       ],
+       "schemaVersion": 14,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "instance",
+                "options": [ ],
+                "query": "label_values(process_cpu_seconds_total{cluster=\"$cluster\", job=\"kube-controller-manager\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Controller Manager",
+       "uid": "72e0e05bef5099e5f049b05fdc429ed4",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: controller-manager
+  namespace: default

--- a/deploy/dashboards/k8s-resources-cluster.yaml
+++ b/deploy/dashboards/k8s-resources-cluster.yaml
@@ -1,0 +1,2657 @@
+apiVersion: v1
+data:
+  k8s-resources-cluster.json: |
+    {
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": true,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "links": [ ],
+       "refresh": "10s",
+       "rows": [
+          {
+             "collapse": false,
+             "height": "100px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "format": "percentunit",
+                   "id": 1,
+                   "interval": "1m",
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 2,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "1 - avg(rate(node_cpu_seconds_total{mode=\"idle\", cluster=\"$cluster\"}[$__rate_interval]))",
+                         "format": "time_series",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "70,80",
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Utilisation",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "singlestat",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "format": "percentunit",
+                   "id": 2,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 2,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"cpu\",cluster=\"$cluster\"})",
+                         "format": "time_series",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "70,80",
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Requests Commitment",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "singlestat",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "format": "percentunit",
+                   "id": 3,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 2,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(kube_pod_container_resource_limits{cluster=\"$cluster\", resource=\"cpu\"}) / sum(kube_node_status_allocatable{resource=\"cpu\",cluster=\"$cluster\"})",
+                         "format": "time_series",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "70,80",
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Limits Commitment",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "singlestat",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "format": "percentunit",
+                   "id": 4,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 2,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum{cluster=\"$cluster\"}) / sum(node_memory_MemTotal_bytes{cluster=\"$cluster\"})",
+                         "format": "time_series",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "70,80",
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Utilisation",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "singlestat",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "format": "percentunit",
+                   "id": 5,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 2,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(namespace_memory:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) / sum(kube_node_status_allocatable{resource=\"memory\",cluster=\"$cluster\"})",
+                         "format": "time_series",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "70,80",
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Requests Commitment",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "singlestat",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "format": "percentunit",
+                   "id": 6,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 2,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(kube_pod_container_resource_limits{cluster=\"$cluster\", resource=\"memory\"}) / sum(kube_node_status_allocatable{resource=\"memory\",cluster=\"$cluster\"})",
+                         "format": "time_series",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "70,80",
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Limits Commitment",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "singlestat",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Headlines",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 7,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\"}) by (namespace)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{namespace}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 8,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "Pods",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 0,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down to pods",
+                         "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "Workloads",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 0,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down to workloads",
+                         "linkUrl": "./d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Usage",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Requests",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Requests %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "CPU Limits",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Limits %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #G",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Namespace",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down to pods",
+                         "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
+                         "pattern": "namespace",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum(kube_pod_owner{cluster=\"$cluster\"}) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\"}) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(namespace_cpu:kube_pod_container_resource_requests:sum{cluster=\"$cluster\"}) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\"}) by (namespace) / sum(kube_pod_container_resource_requests{cluster=\"$cluster\", resource=\"cpu\"}) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_limits{cluster=\"$cluster\", resource=\"cpu\"}) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\"}) by (namespace) / sum(kube_pod_container_resource_limits{cluster=\"$cluster\", resource=\"cpu\"}) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "G",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Quota",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU Quota",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 9,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(container_memory_rss{cluster=\"$cluster\", container!=\"\"}) by (namespace)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{namespace}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Usage (w/o cache)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Memory",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 10,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "Pods",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 0,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down to pods",
+                         "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "Workloads",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 0,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down to workloads",
+                         "linkUrl": "./d/a87fb0d919ec0ea5f6543124e16c42a5/k8s-resources-workloads-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell_1",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "Memory Usage",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Requests",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Requests %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Memory Limits",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Limits %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #G",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Namespace",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down to pods",
+                         "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
+                         "pattern": "namespace",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum(kube_pod_owner{cluster=\"$cluster\"}) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "count(avg(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\"}) by (workload, namespace)) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_rss{cluster=\"$cluster\", container!=\"\"}) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_requests{cluster=\"$cluster\", resource=\"memory\"}) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_rss{cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(kube_pod_container_resource_requests{cluster=\"$cluster\", resource=\"memory\"}) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_limits{cluster=\"$cluster\", resource=\"memory\"}) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_rss{cluster=\"$cluster\", container!=\"\"}) by (namespace) / sum(kube_pod_container_resource_limits{cluster=\"$cluster\", resource=\"memory\"}) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "G",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Requests by Namespace",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Memory Requests",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 11,
+                   "interval": "1m",
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "Current Receive Bandwidth",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Current Transmit Bandwidth",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Rate of Received Packets",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Rate of Transmitted Packets",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Rate of Received Packets Dropped",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Rate of Transmitted Packets Dropped",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Namespace",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down to pods",
+                         "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
+                         "pattern": "namespace",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Current Network Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Current Network Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 12,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{namespace}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Receive Bandwidth",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 13,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{namespace}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Transmit Bandwidth",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Bandwidth",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 14,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{namespace}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Average Container Bandwidth by Namespace: Received",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 15,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{namespace}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Average Container Bandwidth by Namespace: Transmitted",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Average Container Bandwidth by Namespace",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 16,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{namespace}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 17,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{namespace}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Rate of Packets",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 18,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{namespace}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets Dropped",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 19,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{namespace}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets Dropped",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Rate of Packets Dropped",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "decimals": -1,
+                   "fill": 10,
+                   "id": 20,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "ceil(sum by(namespace) (rate(container_fs_reads_total{container!=\"\", cluster=\"$cluster\"}[5m]) + rate(container_fs_writes_total{container!=\"\", cluster=\"$cluster\"}[5m])))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{namespace}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "IOPS(Reads+Writes)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 21,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{container!=\"\", cluster=\"$cluster\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\", cluster=\"$cluster\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{namespace}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "ThroughPut(Read+Write)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Storage IO",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 22,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "sort": {
+                      "col": 4,
+                      "desc": true
+                   },
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "IOPS(Reads)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": -1,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "IOPS(Writes)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": -1,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "IOPS(Reads + Writes)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": -1,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "Throughput(Read)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Throughput(Write)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Throughput(Read + Write)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Namespace",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down to pods",
+                         "linkUrl": "./d/85a562078cdf77779eaa1add43ccec1e/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell",
+                         "pattern": "namespace",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum by(namespace) (rate(container_fs_reads_total{container!=\"\", cluster=\"$cluster\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(namespace) (rate(container_fs_writes_total{container!=\"\", cluster=\"$cluster\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(namespace) (rate(container_fs_reads_total{container!=\"\", cluster=\"$cluster\"}[5m]) + rate(container_fs_writes_total{container!=\"\", cluster=\"$cluster\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{container!=\"\", cluster=\"$cluster\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(namespace) (rate(container_fs_writes_bytes_total{container!=\"\", cluster=\"$cluster\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(namespace) (rate(container_fs_reads_bytes_total{container!=\"\", cluster=\"$cluster\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\", cluster=\"$cluster\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Current Storage IO",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Storage IO - Distribution",
+             "titleSize": "h6"
+          }
+       ],
+       "schemaVersion": 14,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(node_cpu_seconds_total, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Compute Resources / Cluster",
+       "uid": "efa86fd1d0c121a26444b636a3f509a8",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: k8s-resources-cluster
+  namespace: default

--- a/deploy/dashboards/k8s-resources-namespace.yaml
+++ b/deploy/dashboards/k8s-resources-namespace.yaml
@@ -1,0 +1,2417 @@
+apiVersion: v1
+data:
+  k8s-resources-namespace.json: |
+    {
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": true,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "links": [ ],
+       "refresh": "10s",
+       "rows": [
+          {
+             "collapse": false,
+             "height": "100px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "format": "percentunit",
+                   "id": 1,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 3,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"})",
+                         "format": "time_series",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "70,80",
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Utilisation (from requests)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "singlestat",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "format": "percentunit",
+                   "id": 2,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 3,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"})",
+                         "format": "time_series",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "70,80",
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Utilisation (from limits)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "singlestat",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "format": "percentunit",
+                   "id": 3,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 3,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
+                         "format": "time_series",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "70,80",
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Utilization (from requests)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "singlestat",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "format": "percentunit",
+                   "id": 4,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 3,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) / sum(kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"})",
+                         "format": "time_series",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "70,80",
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Utilisation (from limits)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "singlestat",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Headlines",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 5,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [
+                      {
+                         "alias": "quota - requests",
+                         "color": "#F2495C",
+                         "dashes": true,
+                         "fill": 0,
+                         "hiddenSeries": true,
+                         "hideTooltip": true,
+                         "legend": true,
+                         "linewidth": 2,
+                         "stack": false
+                      },
+                      {
+                         "alias": "quota - limits",
+                         "color": "#FF9830",
+                         "dashes": true,
+                         "fill": 0,
+                         "hiddenSeries": true,
+                         "hideTooltip": true,
+                         "legend": true,
+                         "linewidth": 2,
+                         "stack": false
+                      }
+                   ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "quota - requests",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "quota - limits",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 6,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "CPU Usage",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Requests",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Requests %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "CPU Limits",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Limits %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Pod",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                         "pattern": "pod",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Quota",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU Quota",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 7,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [
+                      {
+                         "alias": "quota - requests",
+                         "color": "#F2495C",
+                         "dashes": true,
+                         "fill": 0,
+                         "hiddenSeries": true,
+                         "hideTooltip": true,
+                         "legend": true,
+                         "linewidth": 2,
+                         "stack": false
+                      },
+                      {
+                         "alias": "quota - limits",
+                         "color": "#FF9830",
+                         "dashes": true,
+                         "fill": 0,
+                         "hiddenSeries": true,
+                         "hideTooltip": true,
+                         "legend": true,
+                         "linewidth": 2,
+                         "stack": false
+                      }
+                   ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "quota - requests",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "quota - limits",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Usage (w/o cache)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Memory Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 8,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "Memory Usage",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Requests",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Requests %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Memory Limits",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Limits %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Memory Usage (RSS)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Usage (Cache)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #G",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Usage (Swap)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #H",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Pod",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                         "pattern": "pod",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod) / sum(kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_rss{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_cache{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "G",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_swap{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "H",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Quota",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Memory Quota",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 9,
+                   "interval": "1m",
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "Current Receive Bandwidth",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Current Transmit Bandwidth",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Rate of Received Packets",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Rate of Transmitted Packets",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Rate of Received Packets Dropped",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Rate of Transmitted Packets Dropped",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Pod",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down to pods",
+                         "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                         "pattern": "pod",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Current Network Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Current Network Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 10,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Receive Bandwidth",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 11,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Transmit Bandwidth",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Bandwidth",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 12,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 13,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Rate of Packets",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 14,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets Dropped",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 15,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets Dropped",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Rate of Packets Dropped",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "decimals": -1,
+                   "fill": 10,
+                   "id": 16,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "IOPS(Reads+Writes)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 17,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "ThroughPut(Read+Write)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Storage IO",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 18,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "sort": {
+                      "col": 4,
+                      "desc": true
+                   },
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "IOPS(Reads)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": -1,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "IOPS(Writes)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": -1,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "IOPS(Reads + Writes)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": -1,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "Throughput(Read)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Throughput(Write)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Throughput(Read + Write)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Pod",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down to containers",
+                         "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                         "pattern": "pod",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(pod) (rate(container_fs_writes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Current Storage IO",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Storage IO - Distribution",
+             "titleSize": "h6"
+          }
+       ],
+       "schemaVersion": 14,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "namespace",
+                "options": [ ],
+                "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Compute Resources / Namespace (Pods)",
+       "uid": "85a562078cdf77779eaa1add43ccec1e",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: k8s-resources-namespace
+  namespace: default

--- a/deploy/dashboards/k8s-resources-node.yaml
+++ b/deploy/dashboards/k8s-resources-node.yaml
@@ -1,0 +1,843 @@
+apiVersion: v1
+data:
+  k8s-resources-node.json: |
+    {
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": true,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "links": [ ],
+       "refresh": "10s",
+       "rows": [
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 1,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 2,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "CPU Usage",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Requests",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Requests %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "CPU Limits",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Limits %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Pod",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "pod",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", node=~\"$node\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\", resource=\"cpu\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\", resource=\"cpu\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\", resource=\"cpu\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", node=~\"$node\"}) by (pod) / sum(kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\", resource=\"cpu\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Quota",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU Quota",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 3,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Usage (w/o cache)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Memory Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 4,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "Memory Usage",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Requests",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Requests %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Memory Limits",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Limits %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Memory Usage (RSS)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Usage (Cache)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #G",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Usage (Swap)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #H",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Pod",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "pod",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\", resource=\"memory\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(kube_pod_container_resource_requests{cluster=\"$cluster\", node=~\"$node\", resource=\"memory\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\", resource=\"memory\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod) / sum(kube_pod_container_resource_limits{cluster=\"$cluster\", node=~\"$node\", resource=\"memory\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_memory_rss{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_memory_cache{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "G",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_memory_swap{cluster=\"$cluster\", node=~\"$node\",container!=\"\"}) by (pod)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "H",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Quota",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Memory Quota",
+             "titleSize": "h6"
+          }
+       ],
+       "schemaVersion": 14,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": true,
+                "name": "node",
+                "options": [ ],
+                "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, node)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Compute Resources / Node (Pods)",
+       "uid": "200ac8fdbfbb74b39aff88118e4d1c2c",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: k8s-resources-node
+  namespace: default

--- a/deploy/dashboards/k8s-resources-pod.yaml
+++ b/deploy/dashboards/k8s-resources-pod.yaml
@@ -1,0 +1,2142 @@
+apiVersion: v1
+data:
+  k8s-resources-pod.json: |
+    {
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": true,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "links": [ ],
+       "refresh": "10s",
+       "rows": [
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 1,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [
+                      {
+                         "alias": "requests",
+                         "color": "#F2495C",
+                         "fill": 0,
+                         "hideTooltip": true,
+                         "legend": true,
+                         "linewidth": 2,
+                         "stack": false
+                      },
+                      {
+                         "alias": "limits",
+                         "color": "#FF9830",
+                         "fill": 0,
+                         "hideTooltip": true,
+                         "legend": true,
+                         "linewidth": 2,
+                         "stack": false
+                      }
+                   ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod=\"$pod\", cluster=\"$cluster\"}) by (container)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{container}}",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "requests",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}\n)\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "limits",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 2,
+                   "legend": {
+                      "avg": false,
+                      "current": true,
+                      "max": true,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[5m])) by (container) /sum(increase(container_cpu_cfs_periods_total{namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[5m])) by (container)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{container}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [
+                      {
+                         "colorMode": "critical",
+                         "fill": true,
+                         "line": true,
+                         "op": "gt",
+                         "value": 0.25,
+                         "yaxis": "left"
+                      }
+                   ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Throttling",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "percentunit",
+                         "label": null,
+                         "logBase": 1,
+                         "max": 1,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU Throttling",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 3,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "CPU Usage",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Requests",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Requests %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "CPU Limits",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Limits %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Container",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "container",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"cpu\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Quota",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU Quota",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 4,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [
+                      {
+                         "alias": "requests",
+                         "color": "#F2495C",
+                         "dashes": true,
+                         "fill": 0,
+                         "hideTooltip": true,
+                         "legend": true,
+                         "linewidth": 2,
+                         "stack": false
+                      },
+                      {
+                         "alias": "limits",
+                         "color": "#FF9830",
+                         "dashes": true,
+                         "fill": 0,
+                         "hideTooltip": true,
+                         "legend": true,
+                         "linewidth": 2,
+                         "stack": false
+                      }
+                   ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{container}}",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "requests",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}\n)\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "limits",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Usage (WSS)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Memory Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 5,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "Memory Usage (WSS)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Requests",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Requests %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Memory Limits",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Limits %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Memory Usage (RSS)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Usage (Cache)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #G",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Usage (Swap)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #H",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Container",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "container",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", image!=\"\"}) by (container) / sum(kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container) / sum(kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", resource=\"memory\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_rss{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_cache{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "G",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(container_memory_swap{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "H",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Quota",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Memory Quota",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 6,
+                   "interval": "1m",
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Receive Bandwidth",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 7,
+                   "interval": "1m",
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Transmit Bandwidth",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Bandwidth",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 8,
+                   "interval": "1m",
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 9,
+                   "interval": "1m",
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Rate of Packets",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 10,
+                   "interval": "1m",
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets Dropped",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 11,
+                   "interval": "1m",
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets Dropped",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Rate of Packets Dropped",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "decimals": -1,
+                   "fill": 10,
+                   "id": 12,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "Reads",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "ceil(sum by(pod) (rate(container_fs_writes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "Writes",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "IOPS",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 13,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "Reads",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "Writes",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "ThroughPut",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Storage IO - Distribution(Pod - Read & Writes)",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "decimals": -1,
+                   "fill": 10,
+                   "id": 14,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "ceil(sum by(container) (rate(container_fs_reads_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=\"$pod\"}[5m])))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "IOPS(Reads+Writes)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 15,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum by(container) (rate(container_fs_reads_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=\"$pod\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "ThroughPut(Read+Write)",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Storage IO - Distribution(Containers)",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 16,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "sort": {
+                      "col": 4,
+                      "desc": true
+                   },
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "IOPS(Reads)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": -1,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "IOPS(Writes)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": -1,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "IOPS(Reads + Writes)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": -1,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "Throughput(Read)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Throughput(Write)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Throughput(Read + Write)",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Pod",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down to pods",
+                         "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                         "pattern": "pod",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum by(container) (rate(container_fs_reads_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=\"$pod\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(container) (rate(container_fs_writes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=\"$pod\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(container) (rate(container_fs_reads_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=\"$pod\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(container) (rate(container_fs_reads_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=\"$pod\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(container) (rate(container_fs_writes_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=\"$pod\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum by(container) (rate(container_fs_reads_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\", cluster=\"$cluster\",namespace=~\"$namespace\", pod=\"$pod\"}[5m]))",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Current Storage IO",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Storage IO - Distribution",
+             "titleSize": "h6"
+          }
+       ],
+       "schemaVersion": 14,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "namespace",
+                "options": [ ],
+                "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "pod",
+                "options": [ ],
+                "query": "label_values(kube_pod_info{cluster=\"$cluster\", namespace=\"$namespace\"}, pod)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Compute Resources / Pod",
+       "uid": "6581e46e4e5c7ba40a07646395ef7b23",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: k8s-resources-pod
+  namespace: default

--- a/deploy/dashboards/k8s-resources-workload.yaml
+++ b/deploy/dashboards/k8s-resources-workload.yaml
@@ -1,0 +1,1733 @@
+apiVersion: v1
+data:
+  k8s-resources-workload.json: |
+    {
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": true,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "links": [ ],
+       "refresh": "10s",
+       "rows": [
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 1,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 2,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "CPU Usage",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Requests",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Requests %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "CPU Limits",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Limits %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Pod",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                         "pattern": "pod",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Quota",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU Quota",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 3,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Memory Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 4,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "Memory Usage",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Requests",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Requests %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Memory Limits",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Limits %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Pod",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                         "pattern": "pod",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n/sum(\n    kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\", workload_type=\"$type\"}\n) by (pod)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Quota",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Memory Quota",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 5,
+                   "interval": "1m",
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "Current Receive Bandwidth",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Current Transmit Bandwidth",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Rate of Received Packets",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Rate of Transmitted Packets",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Rate of Received Packets Dropped",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Rate of Transmitted Packets Dropped",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Pod",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                         "pattern": "pod",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Current Network Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Current Network Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 6,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Receive Bandwidth",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 7,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Transmit Bandwidth",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Bandwidth",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 8,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Average Container Bandwidth by Pod: Received",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 9,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Average Container Bandwidth by Pod: Transmitted",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Average Container Bandwidth by Pod",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 10,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 11,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Rate of Packets",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 12,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets Dropped",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 13,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{pod}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets Dropped",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Rate of Packets Dropped",
+             "titleSize": "h6"
+          }
+       ],
+       "schemaVersion": 14,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "namespace",
+                "options": [ ],
+                "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "workload",
+                "options": [ ],
+                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\"}, workload)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "type",
+                "options": [ ],
+                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=\"$workload\"}, workload_type)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Compute Resources / Workload",
+       "uid": "a164a7f0339f99e89cea5cb47e9be617",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: k8s-resources-workload
+  namespace: default

--- a/deploy/dashboards/k8s-resources-workloads-namespace.yaml
+++ b/deploy/dashboards/k8s-resources-workloads-namespace.yaml
@@ -1,0 +1,1886 @@
+apiVersion: v1
+data:
+  k8s-resources-workloads-namespace.json: |
+    {
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": true,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "links": [ ],
+       "refresh": "10s",
+       "rows": [
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 1,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [
+                      {
+                         "alias": "quota - requests",
+                         "color": "#F2495C",
+                         "dashes": true,
+                         "fill": 0,
+                         "hiddenSeries": true,
+                         "hideTooltip": true,
+                         "legend": true,
+                         "linewidth": 2,
+                         "stack": false
+                      },
+                      {
+                         "alias": "quota - limits",
+                         "color": "#FF9830",
+                         "dashes": true,
+                         "fill": 0,
+                         "hiddenSeries": true,
+                         "hideTooltip": true,
+                         "legend": true,
+                         "linewidth": 2,
+                         "stack": false
+                      }
+                   ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{workload}} - {{workload_type}}",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "quota - requests",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "quota - limits",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 2,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "Running Pods",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 0,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Usage",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Requests",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Requests %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "CPU Limits",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "CPU Limits %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Workload",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "./d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
+                         "pattern": "workload",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "Workload Type",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "workload_type",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "count(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload, workload_type)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n  kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n  kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n  node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"cpu\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU Quota",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "CPU Quota",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 3,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [
+                      {
+                         "alias": "quota - requests",
+                         "color": "#F2495C",
+                         "dashes": true,
+                         "fill": 0,
+                         "hiddenSeries": true,
+                         "hideTooltip": true,
+                         "legend": true,
+                         "linewidth": 2,
+                         "stack": false
+                      },
+                      {
+                         "alias": "quota - limits",
+                         "color": "#FF9830",
+                         "dashes": true,
+                         "fill": 0,
+                         "hiddenSeries": true,
+                         "hideTooltip": true,
+                         "legend": true,
+                         "linewidth": 2,
+                         "stack": false
+                      }
+                   ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{workload}} - {{workload_type}}",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "quota - requests",
+                         "legendLink": null,
+                         "step": 10
+                      },
+                      {
+                         "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "quota - limits",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Memory Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 4,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "Running Pods",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 0,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "Memory Usage",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Requests",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Requests %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Memory Limits",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "bytes"
+                      },
+                      {
+                         "alias": "Memory Limits %",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "percentunit"
+                      },
+                      {
+                         "alias": "Workload",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "./d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$__cell_2",
+                         "pattern": "workload",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "Workload Type",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "workload_type",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "count(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}) by (workload, workload_type)",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n  kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_requests{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n  kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "sum(\n    container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\", image!=\"\"}\n  * on(namespace,pod)\n    group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n/sum(\n  kube_pod_container_resource_limits{cluster=\"$cluster\", namespace=\"$namespace\", resource=\"memory\"}\n* on(namespace,pod)\n  group_left(workload, workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=\"$type\"}\n) by (workload, workload_type)\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory Quota",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Memory Quota",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "id": 5,
+                   "interval": "1m",
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "styles": [
+                      {
+                         "alias": "Time",
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "pattern": "Time",
+                         "type": "hidden"
+                      },
+                      {
+                         "alias": "Current Receive Bandwidth",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #A",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Current Transmit Bandwidth",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #B",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "Bps"
+                      },
+                      {
+                         "alias": "Rate of Received Packets",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #C",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Rate of Transmitted Packets",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #D",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Rate of Received Packets Dropped",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #E",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Rate of Transmitted Packets Dropped",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "Value #F",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "pps"
+                      },
+                      {
+                         "alias": "Workload",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": true,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down to pods",
+                         "linkUrl": "./d/a164a7f0339f99e89cea5cb47e9be617/k8s-resources-workload?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-workload=$__cell&var-type=$type",
+                         "pattern": "workload",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "Workload Type",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "link": false,
+                         "linkTargetBlank": false,
+                         "linkTooltip": "Drill down",
+                         "linkUrl": "",
+                         "pattern": "workload_type",
+                         "thresholds": [ ],
+                         "type": "number",
+                         "unit": "short"
+                      },
+                      {
+                         "alias": "",
+                         "colorMode": null,
+                         "colors": [ ],
+                         "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                         "decimals": 2,
+                         "pattern": "/.*/",
+                         "thresholds": [ ],
+                         "type": "string",
+                         "unit": "short"
+                      }
+                   ],
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A",
+                         "step": 10
+                      },
+                      {
+                         "expr": "(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "B",
+                         "step": 10
+                      },
+                      {
+                         "expr": "(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "C",
+                         "step": 10
+                      },
+                      {
+                         "expr": "(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "D",
+                         "step": 10
+                      },
+                      {
+                         "expr": "(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "E",
+                         "step": 10
+                      },
+                      {
+                         "expr": "(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "table",
+                         "instant": true,
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "F",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Current Network Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "transform": "table",
+                   "type": "table",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Current Network Usage",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 6,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{workload}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Receive Bandwidth",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 7,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{workload}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Transmit Bandwidth",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Bandwidth",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 8,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{workload}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Average Container Bandwidth by Workload: Received",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 9,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{workload}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Average Container Bandwidth by Workload: Transmitted",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Average Container Bandwidth by Workload",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 10,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{workload}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 11,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{workload}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Rate of Packets",
+             "titleSize": "h6"
+          },
+          {
+             "collapse": false,
+             "height": "250px",
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 12,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{workload}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets Dropped",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 10,
+                   "id": 13,
+                   "legend": {
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "show": true,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 0,
+                   "links": [ ],
+                   "nullPointMode": "null as zero",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{workload}}",
+                         "legendLink": null,
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets Dropped",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": false
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Rate of Packets Dropped",
+             "titleSize": "h6"
+          }
+       ],
+       "schemaVersion": 14,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "deployment",
+                   "value": "deployment"
+                },
+                "datasource": "$datasource",
+                "definition": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\"}, workload_type)",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "type",
+                "options": [ ],
+                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=~\"$namespace\", workload=~\".+\"}, workload_type)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "namespace",
+                "options": [ ],
+                "query": "label_values(kube_pod_info{cluster=\"$cluster\"}, namespace)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Compute Resources / Namespace (Workloads)",
+       "uid": "a87fb0d919ec0ea5f6543124e16c42a5",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: k8s-resources-workloads-namespace
+  namespace: default

--- a/deploy/dashboards/kubelet.yaml
+++ b/deploy/dashboards/kubelet.yaml
@@ -1,0 +1,2258 @@
+apiVersion: v1
+data:
+  kubelet.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": false,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "id": null,
+       "links": [ ],
+       "refresh": "10s",
+       "rows": [
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                   ],
+                   "datasource": "$datasource",
+                   "format": "none",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": false,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 2,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 2,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "sum(up{cluster=\"$cluster\", job=\"kubelet\"}, metrics_path=\"/metrics\")",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "",
+                   "title": "Up",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "min"
+                },
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                   ],
+                   "datasource": "$datasource",
+                   "format": "none",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": false,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 3,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 2,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "sum(kubelet_running_pods{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}) OR sum(kubelet_running_pod_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "",
+                   "title": "Running Pods",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "min"
+                },
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                   ],
+                   "datasource": "$datasource",
+                   "format": "none",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": false,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 4,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 2,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "sum(kubelet_running_containers{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}) OR sum(kubelet_running_container_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "",
+                   "title": "Running Container",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "min"
+                },
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                   ],
+                   "datasource": "$datasource",
+                   "format": "none",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": false,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 5,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 2,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "sum(volume_manager_total_volumes{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\", state=\"actual_state_of_world\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "",
+                   "title": "Actual Volume Count",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "min"
+                },
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                   ],
+                   "datasource": "$datasource",
+                   "format": "none",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": false,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 6,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 2,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "sum(volume_manager_total_volumes{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\",state=\"desired_state_of_world\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "",
+                   "title": "Desired Volume Count",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "min"
+                },
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                   ],
+                   "datasource": "$datasource",
+                   "format": "none",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": false,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 7,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 2,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "sum(rate(kubelet_node_config_error{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "",
+                   "title": "Config Error Count",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "min"
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 8,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(kubelet_runtime_operations_total{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (operation_type, instance)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{operation_type}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Operation Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 9,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(kubelet_runtime_operations_errors_total{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, operation_type)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{operation_type}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Operation Error Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 10,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(kubelet_runtime_operations_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, operation_type, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{operation_type}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Operation duration 99th quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 11,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(kubelet_pod_start_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} pod",
+                         "refId": "A"
+                      },
+                      {
+                         "expr": "sum(rate(kubelet_pod_worker_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} worker",
+                         "refId": "B"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Pod Start Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 12,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(kubelet_pod_start_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} pod",
+                         "refId": "A"
+                      },
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} worker",
+                         "refId": "B"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Pod Start Duration",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 13,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(storage_operation_duration_seconds_count{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, operation_name, volume_plugin)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Storage Operation Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 14,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(storage_operation_errors_total{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, operation_name, volume_plugin)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Storage Operation Error Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 15,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(storage_operation_duration_seconds_bucket{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, operation_name, volume_plugin, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{operation_name}} {{volume_plugin}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Storage Operation Duration 99th quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 16,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(kubelet_cgroup_manager_duration_seconds_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, operation_type)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{operation_type}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Cgroup manager operation rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 17,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(kubelet_cgroup_manager_duration_seconds_bucket{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, operation_type, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{operation_type}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Cgroup manager 99th quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "description": "Pod lifecycle event generator",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 18,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(kubelet_pleg_relist_duration_seconds_count{cluster=\"$cluster\", job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "PLEG relist rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 19,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_interval_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "PLEG relist interval",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 20,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])) by (instance, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "PLEG relist duration",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 21,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "2xx",
+                         "refId": "A"
+                      },
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "3xx",
+                         "refId": "B"
+                      },
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "4xx",
+                         "refId": "C"
+                      },
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "5xx",
+                         "refId": "D"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "RPC Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 22,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\",job=\"kubelet\", instance=~\"$instance\"}[5m])) by (instance, verb, url, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} {{verb}} {{url}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Request duration 99th quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 23,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "process_resident_memory_bytes{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 24,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}[5m])",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 25,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "go_goroutines{cluster=\"$cluster\",job=\"kubelet\",instance=~\"$instance\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Goroutines",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          }
+       ],
+       "schemaVersion": 14,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "instance",
+                "options": [ ],
+                "query": "label_values(kubelet_runtime_operations_total{cluster=\"$cluster\", job=\"kubelet\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Kubelet",
+       "uid": "3138fa155d5915769fbded898ac09fd9",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: kubelet
+  namespace: default

--- a/deploy/dashboards/namespace-by-pod.yaml
+++ b/deploy/dashboards/namespace-by-pod.yaml
@@ -1,0 +1,1317 @@
+apiVersion: v1
+data:
+  namespace-by-pod.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [
+             {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+             }
+          ]
+       },
+       "editable": true,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "id": null,
+       "links": [ ],
+       "panels": [
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 2,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Current Bandwidth",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "cacheTimeout": null,
+             "colorBackground": false,
+             "colorValue": false,
+             "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+             ],
+             "datasource": "$datasource",
+             "decimals": 0,
+             "format": "time_series",
+             "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 1
+             },
+             "height": 9,
+             "id": 3,
+             "interval": null,
+             "links": [ ],
+             "mappingType": 1,
+             "mappingTypes": [
+                {
+                   "name": "value to text",
+                   "value": 1
+                },
+                {
+                   "name": "range to text",
+                   "value": 2
+                }
+             ],
+             "maxDataPoints": 100,
+             "minSpan": 12,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {
+                "fieldOptions": {
+                   "calcs": [
+                      "last"
+                   ],
+                   "defaults": {
+                      "max": 10000000000,
+                      "min": 0,
+                      "title": "$namespace",
+                      "unit": "Bps"
+                   },
+                   "mappings": [ ],
+                   "override": { },
+                   "thresholds": [
+                      {
+                         "color": "dark-green",
+                         "index": 0,
+                         "value": null
+                      },
+                      {
+                         "color": "dark-yellow",
+                         "index": 1,
+                         "value": 5000000000
+                      },
+                      {
+                         "color": "dark-red",
+                         "index": 2,
+                         "value": 7000000000
+                      }
+                   ],
+                   "values": false
+                }
+             },
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+                {
+                   "from": "null",
+                   "text": "N/A",
+                   "to": "null"
+                }
+             ],
+             "span": 12,
+             "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+             },
+             "tableColumn": "",
+             "targets": [
+                {
+                   "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution]))",
+                   "format": "time_series",
+                   "instant": null,
+                   "intervalFactor": 1,
+                   "legendFormat": "",
+                   "refId": "A"
+                }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Rate of Bytes Received",
+             "type": "gauge",
+             "valueFontSize": "80%",
+             "valueMaps": [
+                {
+                   "op": "=",
+                   "text": "N/A",
+                   "value": "null"
+                }
+             ],
+             "valueName": "current"
+          },
+          {
+             "cacheTimeout": null,
+             "colorBackground": false,
+             "colorValue": false,
+             "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+             ],
+             "datasource": "$datasource",
+             "decimals": 0,
+             "format": "time_series",
+             "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 1
+             },
+             "height": 9,
+             "id": 4,
+             "interval": null,
+             "links": [ ],
+             "mappingType": 1,
+             "mappingTypes": [
+                {
+                   "name": "value to text",
+                   "value": 1
+                },
+                {
+                   "name": "range to text",
+                   "value": 2
+                }
+             ],
+             "maxDataPoints": 100,
+             "minSpan": 12,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {
+                "fieldOptions": {
+                   "calcs": [
+                      "last"
+                   ],
+                   "defaults": {
+                      "max": 10000000000,
+                      "min": 0,
+                      "title": "$namespace",
+                      "unit": "Bps"
+                   },
+                   "mappings": [ ],
+                   "override": { },
+                   "thresholds": [
+                      {
+                         "color": "dark-green",
+                         "index": 0,
+                         "value": null
+                      },
+                      {
+                         "color": "dark-yellow",
+                         "index": 1,
+                         "value": 5000000000
+                      },
+                      {
+                         "color": "dark-red",
+                         "index": 2,
+                         "value": 7000000000
+                      }
+                   ],
+                   "values": false
+                }
+             },
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+                {
+                   "from": "null",
+                   "text": "N/A",
+                   "to": "null"
+                }
+             ],
+             "span": 12,
+             "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+             },
+             "tableColumn": "",
+             "targets": [
+                {
+                   "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution]))",
+                   "format": "time_series",
+                   "instant": null,
+                   "intervalFactor": 1,
+                   "legendFormat": "",
+                   "refId": "A"
+                }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Rate of Bytes Transmitted",
+             "type": "gauge",
+             "valueFontSize": "80%",
+             "valueMaps": [
+                {
+                   "op": "=",
+                   "text": "N/A",
+                   "value": "null"
+                }
+             ],
+             "valueName": "current"
+          },
+          {
+             "columns": [
+                {
+                   "text": "Time",
+                   "value": "Time"
+                },
+                {
+                   "text": "Value #A",
+                   "value": "Value #A"
+                },
+                {
+                   "text": "Value #B",
+                   "value": "Value #B"
+                },
+                {
+                   "text": "Value #C",
+                   "value": "Value #C"
+                },
+                {
+                   "text": "Value #D",
+                   "value": "Value #D"
+                },
+                {
+                   "text": "Value #E",
+                   "value": "Value #E"
+                },
+                {
+                   "text": "Value #F",
+                   "value": "Value #F"
+                },
+                {
+                   "text": "pod",
+                   "value": "pod"
+                }
+             ],
+             "datasource": "$datasource",
+             "fill": 1,
+             "fontSize": "100%",
+             "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 10
+             },
+             "id": 5,
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "minSpan": 24,
+             "nullPointMode": "null as zero",
+             "renderer": "flot",
+             "scroll": true,
+             "showHeader": true,
+             "sort": {
+                "col": 0,
+                "desc": false
+             },
+             "spaceLength": 10,
+             "span": 24,
+             "styles": [
+                {
+                   "alias": "Time",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Time",
+                   "thresholds": [ ],
+                   "type": "hidden",
+                   "unit": "short"
+                },
+                {
+                   "alias": "Bandwidth Received",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #A",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "Bps"
+                },
+                {
+                   "alias": "Bandwidth Transmitted",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #B",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "Bps"
+                },
+                {
+                   "alias": "Rate of Received Packets",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #C",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "pps"
+                },
+                {
+                   "alias": "Rate of Transmitted Packets",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #D",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "pps"
+                },
+                {
+                   "alias": "Rate of Received Packets Dropped",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #E",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "pps"
+                },
+                {
+                   "alias": "Rate of Transmitted Packets Dropped",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #F",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "pps"
+                },
+                {
+                   "alias": "Pod",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": true,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "d/7a18067ce943a40ae25454675c19ff5c/kubernetes-networking-pod?orgId=1&refresh=30s&var-namespace=$namespace&var-pod=$__cell",
+                   "pattern": "pod",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "short"
+                }
+             ],
+             "targets": [
+                {
+                   "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "A",
+                   "step": 10
+                },
+                {
+                   "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "B",
+                   "step": 10
+                },
+                {
+                   "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "C",
+                   "step": 10
+                },
+                {
+                   "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "D",
+                   "step": 10
+                },
+                {
+                   "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "E",
+                   "step": 10
+                },
+                {
+                   "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "F",
+                   "step": 10
+                }
+             ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Status",
+             "type": "table"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 19
+             },
+             "id": 6,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Bandwidth",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 20
+             },
+             "id": 7,
+             "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "total": false,
+                "values": false
+             },
+             "lines": true,
+             "linewidth": 2,
+             "links": [ ],
+             "minSpan": 12,
+             "nullPointMode": "connected",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 12,
+             "stack": true,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{pod}}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Receive Bandwidth",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 20
+             },
+             "id": 8,
+             "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "total": false,
+                "values": false
+             },
+             "lines": true,
+             "linewidth": 2,
+             "links": [ ],
+             "minSpan": 12,
+             "nullPointMode": "connected",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 12,
+             "stack": true,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{pod}}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Transmit Bandwidth",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 29
+             },
+             "id": 9,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 10,
+                      "w": 12,
+                      "x": 0,
+                      "y": 30
+                   },
+                   "id": 10,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{pod}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 10,
+                      "w": 12,
+                      "x": 12,
+                      "y": 30
+                   },
+                   "id": 11,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{pod}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Packets",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 30
+             },
+             "id": 12,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 10,
+                      "w": 12,
+                      "x": 0,
+                      "y": 40
+                   },
+                   "id": 13,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{pod}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets Dropped",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 10,
+                      "w": 12,
+                      "x": 12,
+                      "y": 40
+                   },
+                   "id": 14,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{pod}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets Dropped",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Errors",
+             "titleSize": "h6",
+             "type": "row"
+          }
+       ],
+       "refresh": "10s",
+       "rows": [ ],
+       "schemaVersion": 18,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": ".+",
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "kube-system",
+                   "value": "kube-system"
+                },
+                "datasource": "$datasource",
+                "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "namespace",
+                "options": [ ],
+                "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "5m",
+                   "value": "5m"
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "resolution",
+                "options": [
+                   {
+                      "selected": false,
+                      "text": "30s",
+                      "value": "30s"
+                   },
+                   {
+                      "selected": true,
+                      "text": "5m",
+                      "value": "5m"
+                   },
+                   {
+                      "selected": false,
+                      "text": "1h",
+                      "value": "1h"
+                   }
+                ],
+                "query": "30s,5m,1h",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "interval",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "5m",
+                   "value": "5m"
+                },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "interval",
+                "options": [
+                   {
+                      "selected": true,
+                      "text": "4h",
+                      "value": "4h"
+                   }
+                ],
+                "query": "4h",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "interval",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Networking / Namespace (Pods)",
+       "uid": "8b7a8b326d7a6f1f04244066368c67af",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: namespace-by-pod
+  namespace: default

--- a/deploy/dashboards/namespace-by-workload.yaml
+++ b/deploy/dashboards/namespace-by-workload.yaml
@@ -1,0 +1,1557 @@
+apiVersion: v1
+data:
+  namespace-by-workload.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [
+             {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+             }
+          ]
+       },
+       "editable": true,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "id": null,
+       "links": [ ],
+       "panels": [
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 2,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Current Bandwidth",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "aliasColors": { },
+             "bars": true,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 1
+             },
+             "id": 3,
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": false,
+             "linewidth": 1,
+             "links": [ ],
+             "minSpan": 24,
+             "nullPointMode": "null",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 24,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{ workload }}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Rate of Bytes Received",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "series",
+                "name": null,
+                "show": false,
+                "values": [
+                   "current"
+                ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": true,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 1
+             },
+             "id": 4,
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": false,
+             "linewidth": 1,
+             "links": [ ],
+             "minSpan": 24,
+             "nullPointMode": "null",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 24,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{ workload }}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Rate of Bytes Transmitted",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "series",
+                "name": null,
+                "show": false,
+                "values": [
+                   "current"
+                ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "columns": [
+                {
+                   "text": "Time",
+                   "value": "Time"
+                },
+                {
+                   "text": "Value #A",
+                   "value": "Value #A"
+                },
+                {
+                   "text": "Value #B",
+                   "value": "Value #B"
+                },
+                {
+                   "text": "Value #C",
+                   "value": "Value #C"
+                },
+                {
+                   "text": "Value #D",
+                   "value": "Value #D"
+                },
+                {
+                   "text": "Value #E",
+                   "value": "Value #E"
+                },
+                {
+                   "text": "Value #F",
+                   "value": "Value #F"
+                },
+                {
+                   "text": "Value #G",
+                   "value": "Value #G"
+                },
+                {
+                   "text": "Value #H",
+                   "value": "Value #H"
+                },
+                {
+                   "text": "workload",
+                   "value": "workload"
+                }
+             ],
+             "datasource": "$datasource",
+             "fill": 1,
+             "fontSize": "90%",
+             "gridPos": {
+                "h": 9,
+                "w": 24,
+                "x": 0,
+                "y": 10
+             },
+             "id": 5,
+             "lines": true,
+             "linewidth": 1,
+             "links": [ ],
+             "minSpan": 24,
+             "nullPointMode": "null as zero",
+             "renderer": "flot",
+             "scroll": true,
+             "showHeader": true,
+             "sort": {
+                "col": 0,
+                "desc": false
+             },
+             "spaceLength": 10,
+             "span": 24,
+             "styles": [
+                {
+                   "alias": "Time",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Time",
+                   "thresholds": [ ],
+                   "type": "hidden",
+                   "unit": "short"
+                },
+                {
+                   "alias": "Current Bandwidth Received",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #A",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "Bps"
+                },
+                {
+                   "alias": "Current Bandwidth Transmitted",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #B",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "Bps"
+                },
+                {
+                   "alias": "Average Bandwidth Received",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #C",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "Bps"
+                },
+                {
+                   "alias": "Average Bandwidth Transmitted",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #D",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "Bps"
+                },
+                {
+                   "alias": "Rate of Received Packets",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #E",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "pps"
+                },
+                {
+                   "alias": "Rate of Transmitted Packets",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #F",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "pps"
+                },
+                {
+                   "alias": "Rate of Received Packets Dropped",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #G",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "pps"
+                },
+                {
+                   "alias": "Rate of Transmitted Packets Dropped",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": false,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "",
+                   "pattern": "Value #H",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "pps"
+                },
+                {
+                   "alias": "Workload",
+                   "colorMode": null,
+                   "colors": [ ],
+                   "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                   "decimals": 2,
+                   "link": true,
+                   "linkTooltip": "Drill down",
+                   "linkUrl": "d/728bf77cc1166d2f3133bf25846876cc/kubernetes-networking-workload?orgId=1&refresh=30s&var-namespace=$namespace&var-type=$type&var-workload=$__cell",
+                   "pattern": "workload",
+                   "thresholds": [ ],
+                   "type": "number",
+                   "unit": "short"
+                }
+             ],
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "A",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "B",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "C",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "D",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "E",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "F",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "G",
+                   "step": 10
+                },
+                {
+                   "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "format": "table",
+                   "instant": true,
+                   "intervalFactor": 2,
+                   "legendFormat": "",
+                   "refId": "H",
+                   "step": 10
+                }
+             ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Status",
+             "type": "table"
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 19
+             },
+             "id": 6,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": true,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 0,
+                      "y": 20
+                   },
+                   "id": 7,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "sort": "current",
+                      "sortDesc": true,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": false,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "minSpan": 24,
+                   "nullPointMode": "null",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 24,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{ workload }}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Average Rate of Bytes Received",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "series",
+                      "name": null,
+                      "show": false,
+                      "values": [
+                         "current"
+                      ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": true,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 12,
+                      "y": 20
+                   },
+                   "id": 8,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "sort": "current",
+                      "sortDesc": true,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": false,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "minSpan": 24,
+                   "nullPointMode": "null",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 24,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{ workload }}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Average Rate of Bytes Transmitted",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "series",
+                      "name": null,
+                      "show": false,
+                      "values": [
+                         "current"
+                      ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Average Bandwidth",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 29
+             },
+             "id": 9,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Bandwidth HIstory",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 38
+             },
+             "id": 10,
+             "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "total": false,
+                "values": false
+             },
+             "lines": true,
+             "linewidth": 2,
+             "links": [ ],
+             "minSpan": 12,
+             "nullPointMode": "connected",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 12,
+             "stack": true,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{workload}}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Receive Bandwidth",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 38
+             },
+             "id": 11,
+             "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "total": false,
+                "values": false
+             },
+             "lines": true,
+             "linewidth": 2,
+             "links": [ ],
+             "minSpan": 12,
+             "nullPointMode": "connected",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 12,
+             "stack": true,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{workload}}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Transmit Bandwidth",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 39
+             },
+             "id": 12,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 0,
+                      "y": 40
+                   },
+                   "id": 13,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{workload}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 12,
+                      "y": 40
+                   },
+                   "id": 14,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{workload}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Packets",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 40
+             },
+             "id": 15,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 0,
+                      "y": 41
+                   },
+                   "id": 16,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{workload}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets Dropped",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 12,
+                      "y": 41
+                   },
+                   "id": 17,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\", workload_type=\"$type\"}) by (workload))\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{workload}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets Dropped",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Errors",
+             "titleSize": "h6",
+             "type": "row"
+          }
+       ],
+       "refresh": "10s",
+       "rows": [ ],
+       "schemaVersion": 18,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "kube-system",
+                   "value": "kube-system"
+                },
+                "datasource": "$datasource",
+                "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "namespace",
+                "options": [ ],
+                "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "deployment",
+                   "value": "deployment"
+                },
+                "datasource": "$datasource",
+                "definition": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\"}, workload_type)",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "type",
+                "options": [ ],
+                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\".+\"}, workload_type)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "5m",
+                   "value": "5m"
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "resolution",
+                "options": [
+                   {
+                      "selected": false,
+                      "text": "30s",
+                      "value": "30s"
+                   },
+                   {
+                      "selected": true,
+                      "text": "5m",
+                      "value": "5m"
+                   },
+                   {
+                      "selected": false,
+                      "text": "1h",
+                      "value": "1h"
+                   }
+                ],
+                "query": "30s,5m,1h",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "interval",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "5m",
+                   "value": "5m"
+                },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "interval",
+                "options": [
+                   {
+                      "selected": true,
+                      "text": "4h",
+                      "value": "4h"
+                   }
+                ],
+                "query": "4h",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "interval",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Networking / Namespace (Workload)",
+       "uid": "bbb2a765a623ae38130206c7d94a160f",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: namespace-by-workload
+  namespace: default

--- a/deploy/dashboards/persistentvolumesusage.yaml
+++ b/deploy/dashboards/persistentvolumesusage.yaml
@@ -1,0 +1,504 @@
+apiVersion: v1
+data:
+  persistentvolumesusage.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": false,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "id": null,
+       "links": [ ],
+       "refresh": "10s",
+       "rows": [
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 2,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": true,
+                      "current": true,
+                      "max": true,
+                      "min": true,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 9,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "(\n  sum without(instance, node) (kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n  -\n  sum without(instance, node) (kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n)\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "Used Space",
+                         "refId": "A"
+                      },
+                      {
+                         "expr": "sum without(instance, node) (kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "Free Space",
+                         "refId": "B"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Volume Space Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "rgba(50, 172, 45, 0.97)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(245, 54, 54, 0.9)"
+                   ],
+                   "datasource": "$datasource",
+                   "format": "percent",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": true,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 3,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 3,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "max without(instance,node) (\n(\n  kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"}\n  -\n  kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"}\n)\n/\nkubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"}\n* 100)\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "80, 90",
+                   "title": "Volume Space Usage",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "current"
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 4,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": true,
+                      "current": true,
+                      "max": true,
+                      "min": true,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 9,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum without(instance, node) (kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "Used inodes",
+                         "refId": "A"
+                      },
+                      {
+                         "expr": "(\n  sum without(instance, node) (kubelet_volume_stats_inodes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n  -\n  sum without(instance, node) (kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n)\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": " Free inodes",
+                         "refId": "B"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Volume inodes Usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "none",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "none",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "rgba(50, 172, 45, 0.97)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(245, 54, 54, 0.9)"
+                   ],
+                   "datasource": "$datasource",
+                   "format": "percent",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": true,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 5,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 3,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "max without(instance,node) (\nkubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"}\n/\nkubelet_volume_stats_inodes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"}\n* 100)\n",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "80, 90",
+                   "title": "Volume inodes Usage",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "current"
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          }
+       ],
+       "schemaVersion": 14,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kubelet_volume_stats_capacity_bytes, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "options": [ ],
+                "query": "label_values(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\"}, namespace)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": "PersistentVolumeClaim",
+                "multi": false,
+                "name": "volume",
+                "options": [ ],
+                "query": "label_values(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\"}, persistentvolumeclaim)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-7d",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Persistent Volumes",
+       "uid": "919b92a8e8041bd567af9edab12c840c",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: persistentvolumesusage
+  namespace: default

--- a/deploy/dashboards/pod-total.yaml
+++ b/deploy/dashboards/pod-total.yaml
@@ -1,0 +1,1111 @@
+apiVersion: v1
+data:
+  pod-total.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [
+             {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+             }
+          ]
+       },
+       "editable": true,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "id": null,
+       "links": [ ],
+       "panels": [
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 2,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Current Bandwidth",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "cacheTimeout": null,
+             "colorBackground": false,
+             "colorValue": false,
+             "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+             ],
+             "datasource": "$datasource",
+             "decimals": 0,
+             "format": "time_series",
+             "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 1
+             },
+             "height": 9,
+             "id": 3,
+             "interval": null,
+             "links": [ ],
+             "mappingType": 1,
+             "mappingTypes": [
+                {
+                   "name": "value to text",
+                   "value": 1
+                },
+                {
+                   "name": "range to text",
+                   "value": 2
+                }
+             ],
+             "maxDataPoints": 100,
+             "minSpan": 12,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {
+                "fieldOptions": {
+                   "calcs": [
+                      "last"
+                   ],
+                   "defaults": {
+                      "max": 10000000000,
+                      "min": 0,
+                      "title": "$namespace: $pod",
+                      "unit": "Bps"
+                   },
+                   "mappings": [ ],
+                   "override": { },
+                   "thresholds": [
+                      {
+                         "color": "dark-green",
+                         "index": 0,
+                         "value": null
+                      },
+                      {
+                         "color": "dark-yellow",
+                         "index": 1,
+                         "value": 5000000000
+                      },
+                      {
+                         "color": "dark-red",
+                         "index": 2,
+                         "value": 7000000000
+                      }
+                   ],
+                   "values": false
+                }
+             },
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+                {
+                   "from": "null",
+                   "text": "N/A",
+                   "to": "null"
+                }
+             ],
+             "span": 12,
+             "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+             },
+             "tableColumn": "",
+             "targets": [
+                {
+                   "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution]))",
+                   "format": "time_series",
+                   "instant": null,
+                   "intervalFactor": 1,
+                   "legendFormat": "",
+                   "refId": "A"
+                }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Rate of Bytes Received",
+             "type": "gauge",
+             "valueFontSize": "80%",
+             "valueMaps": [
+                {
+                   "op": "=",
+                   "text": "N/A",
+                   "value": "null"
+                }
+             ],
+             "valueName": "current"
+          },
+          {
+             "cacheTimeout": null,
+             "colorBackground": false,
+             "colorValue": false,
+             "colors": [
+                "#299c46",
+                "rgba(237, 129, 40, 0.89)",
+                "#d44a3a"
+             ],
+             "datasource": "$datasource",
+             "decimals": 0,
+             "format": "time_series",
+             "gauge": {
+                "maxValue": 100,
+                "minValue": 0,
+                "show": false,
+                "thresholdLabels": false,
+                "thresholdMarkers": true
+             },
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 1
+             },
+             "height": 9,
+             "id": 4,
+             "interval": null,
+             "links": [ ],
+             "mappingType": 1,
+             "mappingTypes": [
+                {
+                   "name": "value to text",
+                   "value": 1
+                },
+                {
+                   "name": "range to text",
+                   "value": 2
+                }
+             ],
+             "maxDataPoints": 100,
+             "minSpan": 12,
+             "nullPointMode": "connected",
+             "nullText": null,
+             "options": {
+                "fieldOptions": {
+                   "calcs": [
+                      "last"
+                   ],
+                   "defaults": {
+                      "max": 10000000000,
+                      "min": 0,
+                      "title": "$namespace: $pod",
+                      "unit": "Bps"
+                   },
+                   "mappings": [ ],
+                   "override": { },
+                   "thresholds": [
+                      {
+                         "color": "dark-green",
+                         "index": 0,
+                         "value": null
+                      },
+                      {
+                         "color": "dark-yellow",
+                         "index": 1,
+                         "value": 5000000000
+                      },
+                      {
+                         "color": "dark-red",
+                         "index": 2,
+                         "value": 7000000000
+                      }
+                   ],
+                   "values": false
+                }
+             },
+             "postfix": "",
+             "postfixFontSize": "50%",
+             "prefix": "",
+             "prefixFontSize": "50%",
+             "rangeMaps": [
+                {
+                   "from": "null",
+                   "text": "N/A",
+                   "to": "null"
+                }
+             ],
+             "span": 12,
+             "sparkline": {
+                "fillColor": "rgba(31, 118, 189, 0.18)",
+                "full": false,
+                "lineColor": "rgb(31, 120, 193)",
+                "show": false
+             },
+             "tableColumn": "",
+             "targets": [
+                {
+                   "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution]))",
+                   "format": "time_series",
+                   "instant": null,
+                   "intervalFactor": 1,
+                   "legendFormat": "",
+                   "refId": "A"
+                }
+             ],
+             "thresholds": "",
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Rate of Bytes Transmitted",
+             "type": "gauge",
+             "valueFontSize": "80%",
+             "valueMaps": [
+                {
+                   "op": "=",
+                   "text": "N/A",
+                   "value": "null"
+                }
+             ],
+             "valueName": "current"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 10
+             },
+             "id": 5,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Bandwidth",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 11
+             },
+             "id": 6,
+             "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "total": false,
+                "values": false
+             },
+             "lines": true,
+             "linewidth": 2,
+             "links": [ ],
+             "minSpan": 12,
+             "nullPointMode": "connected",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 12,
+             "stack": true,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{pod}}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Receive Bandwidth",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 11
+             },
+             "id": 7,
+             "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "total": false,
+                "values": false
+             },
+             "lines": true,
+             "linewidth": 2,
+             "links": [ ],
+             "minSpan": 12,
+             "nullPointMode": "connected",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 12,
+             "stack": true,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{pod}}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Transmit Bandwidth",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 20
+             },
+             "id": 8,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 10,
+                      "w": 12,
+                      "x": 0,
+                      "y": 21
+                   },
+                   "id": 9,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{pod}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 10,
+                      "w": 12,
+                      "x": 12,
+                      "y": 21
+                   },
+                   "id": 10,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{pod}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Packets",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 21
+             },
+             "id": 11,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 10,
+                      "w": 12,
+                      "x": 0,
+                      "y": 32
+                   },
+                   "id": 12,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{pod}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets Dropped",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 10,
+                      "w": 12,
+                      "x": 12,
+                      "y": 32
+                   },
+                   "id": 13,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$interval:$resolution])) by (pod)",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{pod}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets Dropped",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Errors",
+             "titleSize": "h6",
+             "type": "row"
+          }
+       ],
+       "refresh": "10s",
+       "rows": [ ],
+       "schemaVersion": 18,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": ".+",
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "kube-system",
+                   "value": "kube-system"
+                },
+                "datasource": "$datasource",
+                "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "namespace",
+                "options": [ ],
+                "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": ".+",
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}, pod)",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "pod",
+                "options": [ ],
+                "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}, pod)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "5m",
+                   "value": "5m"
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "resolution",
+                "options": [
+                   {
+                      "selected": false,
+                      "text": "30s",
+                      "value": "30s"
+                   },
+                   {
+                      "selected": true,
+                      "text": "5m",
+                      "value": "5m"
+                   },
+                   {
+                      "selected": false,
+                      "text": "1h",
+                      "value": "1h"
+                   }
+                ],
+                "query": "30s,5m,1h",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "interval",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "5m",
+                   "value": "5m"
+                },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "interval",
+                "options": [
+                   {
+                      "selected": true,
+                      "text": "4h",
+                      "value": "4h"
+                   }
+                ],
+                "query": "4h",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "interval",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Networking / Pod",
+       "uid": "7a18067ce943a40ae25454675c19ff5c",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: pod-total
+  namespace: default

--- a/deploy/dashboards/proxy.yaml
+++ b/deploy/dashboards/proxy.yaml
@@ -1,0 +1,1098 @@
+apiVersion: v1
+data:
+  proxy.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": false,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "id": null,
+       "links": [ ],
+       "refresh": "10s",
+       "rows": [
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                   ],
+                   "datasource": "$datasource",
+                   "format": "none",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": false,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 2,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 2,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "sum(up{cluster=\"$cluster\", job=\"kube-proxy\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "",
+                   "title": "Up",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "min"
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 3,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 5,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(kubeproxy_sync_proxy_rules_duration_seconds_count{cluster=\"$cluster\", job=\"kube-proxy\", instance=~\"$instance\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "rate",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rules Sync Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 4,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 5,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99,rate(kubeproxy_sync_proxy_rules_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-proxy\", instance=~\"$instance\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rule Sync Latency 99th Quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 5,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(kubeproxy_network_programming_duration_seconds_count{cluster=\"$cluster\", job=\"kube-proxy\", instance=~\"$instance\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "rate",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Network Programming Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 6,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 6,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(kubeproxy_network_programming_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-proxy\", instance=~\"$instance\"}[5m])) by (instance, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Network Programming Latency 99th Quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 7,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"kube-proxy\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "2xx",
+                         "refId": "A"
+                      },
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"kube-proxy\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "3xx",
+                         "refId": "B"
+                      },
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"kube-proxy\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "4xx",
+                         "refId": "C"
+                      },
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"kube-proxy\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "5xx",
+                         "refId": "D"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Kube API Request Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 8,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 8,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-proxy\",instance=~\"$instance\",verb=\"POST\"}[5m])) by (verb, url, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{verb}} {{url}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Post Request Latency 99th Quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 9,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-proxy\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{verb}} {{url}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Get Request Latency 99th Quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 10,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"kube-proxy\",instance=~\"$instance\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 11,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"kube-proxy\",instance=~\"$instance\"}[5m])",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 12,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "go_goroutines{cluster=\"$cluster\", job=\"kube-proxy\",instance=~\"$instance\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Goroutines",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          }
+       ],
+       "schemaVersion": 14,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "instance",
+                "options": [ ],
+                "query": "label_values(kubeproxy_network_programming_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-proxy\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Proxy",
+       "uid": "632e265de029684c40b21cb76bca4f94",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: proxy
+  namespace: default

--- a/deploy/dashboards/scheduler.yaml
+++ b/deploy/dashboards/scheduler.yaml
@@ -1,0 +1,965 @@
+apiVersion: v1
+data:
+  scheduler.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [ ]
+       },
+       "editable": false,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "id": null,
+       "links": [ ],
+       "refresh": "10s",
+       "rows": [
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "cacheTimeout": null,
+                   "colorBackground": false,
+                   "colorValue": false,
+                   "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                   ],
+                   "datasource": "$datasource",
+                   "format": "none",
+                   "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": false,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                   },
+                   "gridPos": { },
+                   "id": 2,
+                   "interval": null,
+                   "links": [ ],
+                   "mappingType": 1,
+                   "mappingTypes": [
+                      {
+                         "name": "value to text",
+                         "value": 1
+                      },
+                      {
+                         "name": "range to text",
+                         "value": 2
+                      }
+                   ],
+                   "maxDataPoints": 100,
+                   "nullPointMode": "connected",
+                   "nullText": null,
+                   "postfix": "",
+                   "postfixFontSize": "50%",
+                   "prefix": "",
+                   "prefixFontSize": "50%",
+                   "rangeMaps": [
+                      {
+                         "from": "null",
+                         "text": "N/A",
+                         "to": "null"
+                      }
+                   ],
+                   "span": 2,
+                   "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                   },
+                   "tableColumn": "",
+                   "targets": [
+                      {
+                         "expr": "sum(up{cluster=\"$cluster\", job=\"kube-scheduler\"})",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": "",
+                   "title": "Up",
+                   "tooltip": {
+                      "shared": false
+                   },
+                   "type": "singlestat",
+                   "valueFontSize": "80%",
+                   "valueMaps": [
+                      {
+                         "op": "=",
+                         "text": "N/A",
+                         "value": "null"
+                      }
+                   ],
+                   "valueName": "min"
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 3,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 5,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(scheduler_e2e_scheduling_duration_seconds_count{cluster=\"$cluster\", job=\"kube-scheduler\", instance=~\"$instance\"}[5m])) by (instance)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} e2e",
+                         "refId": "A"
+                      },
+                      {
+                         "expr": "sum(rate(scheduler_binding_duration_seconds_count{cluster=\"$cluster\", job=\"kube-scheduler\", instance=~\"$instance\"}[5m])) by (instance)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} binding",
+                         "refId": "B"
+                      },
+                      {
+                         "expr": "sum(rate(scheduler_scheduling_algorithm_duration_seconds_count{cluster=\"$cluster\", job=\"kube-scheduler\", instance=~\"$instance\"}[5m])) by (instance)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} scheduling algorithm",
+                         "refId": "C"
+                      },
+                      {
+                         "expr": "sum(rate(scheduler_volume_scheduling_duration_seconds_count{cluster=\"$cluster\", job=\"kube-scheduler\", instance=~\"$instance\"}[5m])) by (instance)",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} volume",
+                         "refId": "D"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Scheduling Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 4,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 5,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-scheduler\",instance=~\"$instance\"}[5m])) by (instance, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} e2e",
+                         "refId": "A"
+                      },
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-scheduler\",instance=~\"$instance\"}[5m])) by (instance, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} binding",
+                         "refId": "B"
+                      },
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-scheduler\",instance=~\"$instance\"}[5m])) by (instance, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} scheduling algorithm",
+                         "refId": "C"
+                      },
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(scheduler_volume_scheduling_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-scheduler\",instance=~\"$instance\"}[5m])) by (instance, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}} volume",
+                         "refId": "D"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Scheduling latency 99th Quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 5,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"kube-scheduler\", instance=~\"$instance\",code=~\"2..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "2xx",
+                         "refId": "A"
+                      },
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"kube-scheduler\", instance=~\"$instance\",code=~\"3..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "3xx",
+                         "refId": "B"
+                      },
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"kube-scheduler\", instance=~\"$instance\",code=~\"4..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "4xx",
+                         "refId": "C"
+                      },
+                      {
+                         "expr": "sum(rate(rest_client_requests_total{cluster=\"$cluster\", job=\"kube-scheduler\", instance=~\"$instance\",code=~\"5..\"}[5m]))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "5xx",
+                         "refId": "D"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Kube API Request Rate",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "ops",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 6,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 8,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-scheduler\", instance=~\"$instance\", verb=\"POST\"}[5m])) by (verb, url, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{verb}} {{url}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Post Request Latency 99th Quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 7,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-scheduler\", instance=~\"$instance\", verb=\"GET\"}[5m])) by (verb, url, le))",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{verb}} {{url}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Get Request Latency 99th Quantile",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "s",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 8,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "process_resident_memory_bytes{cluster=\"$cluster\", job=\"kube-scheduler\", instance=~\"$instance\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Memory",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 9,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "rate(process_cpu_seconds_total{cluster=\"$cluster\", job=\"kube-scheduler\", instance=~\"$instance\"}[5m])",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "CPU usage",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "bytes",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 1,
+                   "fillGradient": 0,
+                   "gridPos": { },
+                   "id": 10,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "nullPointMode": "null",
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 4,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "go_goroutines{cluster=\"$cluster\", job=\"kube-scheduler\",instance=~\"$instance\"}",
+                         "format": "time_series",
+                         "intervalFactor": 2,
+                         "legendFormat": "{{instance}}",
+                         "refId": "A"
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Goroutines",
+                   "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      },
+                      {
+                         "format": "short",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": null,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": false,
+             "title": "Dashboard Row",
+             "titleSize": "h6",
+             "type": "row"
+          }
+       ],
+       "schemaVersion": 14,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "instance",
+                "options": [ ],
+                "query": "label_values(process_cpu_seconds_total{cluster=\"$cluster\", job=\"kube-scheduler\"}, instance)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Scheduler",
+       "uid": "2e6b6a3b4bddf1427b3a55aa1311c656",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: scheduler
+  namespace: default

--- a/deploy/dashboards/workload-total.yaml
+++ b/deploy/dashboards/workload-total.yaml
@@ -1,0 +1,1297 @@
+apiVersion: v1
+data:
+  workload-total.json: |
+    {
+       "__inputs": [ ],
+       "__requires": [ ],
+       "annotations": {
+          "list": [
+             {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+             }
+          ]
+       },
+       "editable": true,
+       "gnetId": null,
+       "graphTooltip": 0,
+       "hideControls": false,
+       "id": null,
+       "links": [ ],
+       "panels": [
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+             },
+             "id": 2,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Current Bandwidth",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "aliasColors": { },
+             "bars": true,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 1
+             },
+             "id": 3,
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": false,
+             "linewidth": 1,
+             "links": [ ],
+             "minSpan": 24,
+             "nullPointMode": "null",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 24,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{ pod }}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Rate of Bytes Received",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "series",
+                "name": null,
+                "show": false,
+                "values": [
+                   "current"
+                ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": true,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 1
+             },
+             "id": 4,
+             "legend": {
+                "alignAsTable": true,
+                "avg": false,
+                "current": true,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": true,
+                "show": true,
+                "sideWidth": null,
+                "sort": "current",
+                "sortDesc": true,
+                "total": false,
+                "values": true
+             },
+             "lines": false,
+             "linewidth": 1,
+             "links": [ ],
+             "minSpan": 24,
+             "nullPointMode": "null",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 24,
+             "stack": false,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{ pod }}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Current Rate of Bytes Transmitted",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "series",
+                "name": null,
+                "show": false,
+                "values": [
+                   "current"
+                ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 10
+             },
+             "id": 5,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": true,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 0,
+                      "y": 11
+                   },
+                   "id": 6,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "sort": "current",
+                      "sortDesc": true,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": false,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "minSpan": 24,
+                   "nullPointMode": "null",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 24,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(avg(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{ pod }}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Average Rate of Bytes Received",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "series",
+                      "name": null,
+                      "show": false,
+                      "values": [
+                         "current"
+                      ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": true,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 12,
+                      "y": 11
+                   },
+                   "id": 7,
+                   "legend": {
+                      "alignAsTable": true,
+                      "avg": false,
+                      "current": true,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": true,
+                      "show": true,
+                      "sideWidth": null,
+                      "sort": "current",
+                      "sortDesc": true,
+                      "total": false,
+                      "values": true
+                   },
+                   "lines": false,
+                   "linewidth": 1,
+                   "links": [ ],
+                   "minSpan": 24,
+                   "nullPointMode": "null",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 24,
+                   "stack": false,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(avg(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{ pod }}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Average Rate of Bytes Transmitted",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "series",
+                      "name": null,
+                      "show": false,
+                      "values": [
+                         "current"
+                      ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "Bps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Average Bandwidth",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": false,
+             "collapsed": false,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 11
+             },
+             "id": 8,
+             "panels": [ ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Bandwidth HIstory",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 0,
+                "y": 12
+             },
+             "id": 9,
+             "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "total": false,
+                "values": false
+             },
+             "lines": true,
+             "linewidth": 2,
+             "links": [ ],
+             "minSpan": 12,
+             "nullPointMode": "connected",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 12,
+             "stack": true,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{pod}}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Receive Bandwidth",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "aliasColors": { },
+             "bars": false,
+             "dashLength": 10,
+             "dashes": false,
+             "datasource": "$datasource",
+             "fill": 2,
+             "fillGradient": 0,
+             "gridPos": {
+                "h": 9,
+                "w": 12,
+                "x": 12,
+                "y": 12
+             },
+             "id": 10,
+             "legend": {
+                "alignAsTable": false,
+                "avg": false,
+                "current": false,
+                "hideEmpty": true,
+                "hideZero": true,
+                "max": false,
+                "min": false,
+                "rightSide": false,
+                "show": true,
+                "sideWidth": null,
+                "total": false,
+                "values": false
+             },
+             "lines": true,
+             "linewidth": 2,
+             "links": [ ],
+             "minSpan": 12,
+             "nullPointMode": "connected",
+             "paceLength": 10,
+             "percentage": false,
+             "pointradius": 5,
+             "points": false,
+             "renderer": "flot",
+             "repeat": null,
+             "seriesOverrides": [ ],
+             "spaceLength": 10,
+             "span": 12,
+             "stack": true,
+             "steppedLine": false,
+             "targets": [
+                {
+                   "expr": "sort_desc(sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                   "format": "time_series",
+                   "intervalFactor": 1,
+                   "legendFormat": "{{pod}}",
+                   "refId": "A",
+                   "step": 10
+                }
+             ],
+             "thresholds": [ ],
+             "timeFrom": null,
+             "timeShift": null,
+             "title": "Transmit Bandwidth",
+             "tooltip": {
+                "shared": true,
+                "sort": 2,
+                "value_type": "individual"
+             },
+             "type": "graph",
+             "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": [ ]
+             },
+             "yaxes": [
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                },
+                {
+                   "format": "Bps",
+                   "label": null,
+                   "logBase": 1,
+                   "max": null,
+                   "min": 0,
+                   "show": true
+                }
+             ]
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 21
+             },
+             "id": 11,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 0,
+                      "y": 22
+                   },
+                   "id": 12,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(irate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{pod}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 12,
+                      "y": 22
+                   },
+                   "id": 13,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{pod}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Packets",
+             "titleSize": "h6",
+             "type": "row"
+          },
+          {
+             "collapse": true,
+             "collapsed": true,
+             "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 22
+             },
+             "id": 14,
+             "panels": [
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 0,
+                      "y": 23
+                   },
+                   "id": 15,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{pod}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Received Packets Dropped",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                },
+                {
+                   "aliasColors": { },
+                   "bars": false,
+                   "dashLength": 10,
+                   "dashes": false,
+                   "datasource": "$datasource",
+                   "fill": 2,
+                   "fillGradient": 0,
+                   "gridPos": {
+                      "h": 9,
+                      "w": 12,
+                      "x": 12,
+                      "y": 23
+                   },
+                   "id": 16,
+                   "legend": {
+                      "alignAsTable": false,
+                      "avg": false,
+                      "current": false,
+                      "hideEmpty": true,
+                      "hideZero": true,
+                      "max": false,
+                      "min": false,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": false
+                   },
+                   "lines": true,
+                   "linewidth": 2,
+                   "links": [ ],
+                   "minSpan": 12,
+                   "nullPointMode": "connected",
+                   "paceLength": 10,
+                   "percentage": false,
+                   "pointradius": 5,
+                   "points": false,
+                   "renderer": "flot",
+                   "repeat": null,
+                   "seriesOverrides": [ ],
+                   "spaceLength": 10,
+                   "span": 12,
+                   "stack": true,
+                   "steppedLine": false,
+                   "targets": [
+                      {
+                         "expr": "sort_desc(sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$interval:$resolution])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=\"$type\"}) by (pod))\n",
+                         "format": "time_series",
+                         "intervalFactor": 1,
+                         "legendFormat": "{{pod}}",
+                         "refId": "A",
+                         "step": 10
+                      }
+                   ],
+                   "thresholds": [ ],
+                   "timeFrom": null,
+                   "timeShift": null,
+                   "title": "Rate of Transmitted Packets Dropped",
+                   "tooltip": {
+                      "shared": true,
+                      "sort": 2,
+                      "value_type": "individual"
+                   },
+                   "type": "graph",
+                   "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                   },
+                   "yaxes": [
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      },
+                      {
+                         "format": "pps",
+                         "label": null,
+                         "logBase": 1,
+                         "max": null,
+                         "min": 0,
+                         "show": true
+                      }
+                   ]
+                }
+             ],
+             "repeat": null,
+             "repeatIteration": null,
+             "repeatRowId": null,
+             "showTitle": true,
+             "title": "Errors",
+             "titleSize": "h6",
+             "type": "row"
+          }
+       ],
+       "refresh": "10s",
+       "rows": [ ],
+       "schemaVersion": 18,
+       "style": "dark",
+       "tags": [
+          "kubernetes-mixin"
+       ],
+       "templating": {
+          "list": [
+             {
+                "current": {
+                   "text": "default",
+                   "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+             },
+             {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": ".+",
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "kube-system",
+                   "value": "kube-system"
+                },
+                "datasource": "$datasource",
+                "definition": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+                "hide": 0,
+                "includeAll": true,
+                "label": null,
+                "multi": false,
+                "name": "namespace",
+                "options": [ ],
+                "query": "label_values(container_network_receive_packets_total{cluster=\"$cluster\"}, namespace)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "",
+                   "value": ""
+                },
+                "datasource": "$datasource",
+                "definition": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\"}, workload)",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "workload",
+                "options": [ ],
+                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\"}, workload)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "deployment",
+                   "value": "deployment"
+                },
+                "datasource": "$datasource",
+                "definition": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\"}, workload_type)",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "type",
+                "options": [ ],
+                "query": "label_values(namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\"}, workload_type)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 0,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "5m",
+                   "value": "5m"
+                },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "resolution",
+                "options": [
+                   {
+                      "selected": false,
+                      "text": "30s",
+                      "value": "30s"
+                   },
+                   {
+                      "selected": true,
+                      "text": "5m",
+                      "value": "5m"
+                   },
+                   {
+                      "selected": false,
+                      "text": "1h",
+                      "value": "1h"
+                   }
+                ],
+                "query": "30s,5m,1h",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "interval",
+                "useTags": false
+             },
+             {
+                "allValue": null,
+                "auto": false,
+                "auto_count": 30,
+                "auto_min": "10s",
+                "current": {
+                   "text": "5m",
+                   "value": "5m"
+                },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "interval",
+                "options": [
+                   {
+                      "selected": true,
+                      "text": "4h",
+                      "value": "4h"
+                   }
+                ],
+                "query": "4h",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "interval",
+                "useTags": false
+             }
+          ]
+       },
+       "time": {
+          "from": "now-1h",
+          "to": "now"
+       },
+       "timepicker": {
+          "refresh_intervals": [
+             "5s",
+             "10s",
+             "30s",
+             "1m",
+             "5m",
+             "15m",
+             "30m",
+             "1h",
+             "2h",
+             "1d"
+          ],
+          "time_options": [
+             "5m",
+             "15m",
+             "1h",
+             "6h",
+             "12h",
+             "24h",
+             "2d",
+             "7d",
+             "30d"
+          ]
+       },
+       "timezone": "UTC",
+       "title": "Kubernetes / Networking / Workload",
+       "uid": "728bf77cc1166d2f3133bf25846876cc",
+       "version": 0
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  name: workload-total
+  namespace: default

--- a/deploy/promtail-manifests.yaml
+++ b/deploy/promtail-manifests.yaml
@@ -67,7 +67,7 @@ metadata:
 stringData:
   promtail.yaml: "server:\n  log_level: info\n  http_listen_port: 3101\n\nclient:\n
     \ url: http://:@loki.logging.svc.cluster.local:3100/loki/api/v1/push\n  external_labels:\n
-    \   env: dev\n    cluster: local\n  \n\npositions:\n  filename: /run/promtail/positions.yaml\n\nscrape_configs:\n
+    \   env: dev\n    cluster: example.local\n  \n\npositions:\n  filename: /run/promtail/positions.yaml\n\nscrape_configs:\n
     \ # See also https://github.com/grafana/loki/blob/master/production/ksonnet/promtail/scrape_config.libsonnet
     for reference\n  \n  # Pods with a label 'app.kubernetes.io/name'\n  - job_name:
     kubernetes-pods-app-kubernetes-io-name\n    pipeline_stages:\n      - cri: {}\n
@@ -202,7 +202,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 33a68b0ae11d56be14b99469d986b13221f5aa642138c5525abaa0b1b39d58ce
+        checksum/config: d14a68182cb5653a297508f2f0f7cc4a24245f88c57ffe249ef9692db0f85248
       labels:
         app.kubernetes.io/instance: promtail
         app.kubernetes.io/name: promtail

--- a/grafana/promtail/promtail-manifests.yaml
+++ b/grafana/promtail/promtail-manifests.yaml
@@ -32,7 +32,7 @@ stringData:
       url: http://:@loki.logging.svc.cluster.local:3100/loki/api/v1/push
       external_labels:
         env: dev
-        cluster: local
+        cluster: example.local
       
     
     positions:
@@ -423,7 +423,7 @@ spec:
         app.kubernetes.io/name: promtail
         app.kubernetes.io/instance: promtail
       annotations:
-        checksum/config: 33a68b0ae11d56be14b99469d986b13221f5aa642138c5525abaa0b1b39d58ce
+        checksum/config: d14a68182cb5653a297508f2f0f7cc4a24245f88c57ffe249ef9692db0f85248
     spec:
       serviceAccountName: promtail
       securityContext:

--- a/grafana/promtail/values.yaml
+++ b/grafana/promtail/values.yaml
@@ -287,7 +287,7 @@ config:
     extraClientConfigs: |
       external_labels:
         env: dev
-        cluster: local
+        cluster: example.local
 
     # -- You can put here any additional scrape configs you want to add to the config file.
     # @default -- empty

--- a/kube-prometheus/config.libsonnet
+++ b/kube-prometheus/config.libsonnet
@@ -1,0 +1,93 @@
+{
+  _config+:: {
+    SLOs: {
+      apiserver: {
+        days: 30,  // The number of days we alert on burning too much error budget for.
+        target: 0.99,  // The target percentage of availability between 0-1. (0.99 = 99%, 0.999 = 99.9%)
+
+        // Only change these windows when you really understand multi burn rate errors.
+        // Even though you can change the days above (which will change availability calculations)
+        // these windows will alert on a 30 days sliding window. We're looking into basing these windows on the given days too.
+        windows: [
+          { severity: 'critical', 'for': '2m', long: '1h', short: '5m', factor: 14.4 },
+          { severity: 'critical', 'for': '15m', long: '6h', short: '30m', factor: 6 },
+          { severity: 'warning', 'for': '1h', long: '1d', short: '2h', factor: 3 },
+          { severity: 'warning', 'for': '3h', long: '3d', short: '6h', factor: 1 },
+        ],
+      },
+    },
+
+    // Selectors are inserted between {} in Prometheus queries.
+    cadvisorSelector: 'job="cadvisor"',
+    kubeletSelector: 'job="kubelet"',
+    kubeStateMetricsSelector: 'job="kube-state-metrics"',
+    nodeExporterSelector: 'job="node-exporter"',
+    kubeSchedulerSelector: 'job="kube-scheduler"',
+    kubeControllerManagerSelector: 'job="kube-controller-manager"',
+    kubeApiserverSelector: 'job="kube-apiserver"',
+    kubeProxySelector: 'job="kube-proxy"',
+    podLabel: 'pod',
+    hostNetworkInterfaceSelector: 'device!~"veth.+"',
+    hostMountpointSelector: 'mountpoint="/"',
+    wmiExporterSelector: 'job="wmi-exporter"',
+
+    // Grafana dashboard IDs are necessary for stable links for dashboards
+    grafanaDashboardIDs: {
+      'k8s-resources-multicluster.json': '1gBgaexoVZ4TpBNAt2eGRsc4LNjNhdjcZd6cqU6S',
+      'k8s-resources-cluster.json': 'ZnbvYbcXkob7GLqcDPLTj1ZL4MRX87tOh8xdr831',
+      'k8s-resources-namespace.json': 'XaY4UCP3J51an4ikqtkUGBSjLpDW4pg39xe2FuxP',
+      'k8s-resources-pod.json': 'wU56sdGSNYZTL3eO0db3pONtVmTvsyV7w8aadbYF',
+      'k8s-multicluster-rsrc-use.json': 'NJ9AlnsObVgj9uKiJMeAqfzMi1wihOMupcsDhlhR',
+      'k8s-cluster-rsrc-use.json': 'uXQldxzqUNgIOUX6FyZNvqgP2vgYb78daNu4GiDc',
+      'k8s-node-rsrc-use.json': 'E577CMUOwmPsxVVqM9lj40czM1ZPjclw7hGa7OT7',
+      'nodes.json': 'kcb9C2QDe4IYcjiTOmYyfhsImuzxRcvwWC3YLJPS',
+      'persistentvolumesusage.json': 'AhCeikee0xoa6faec0Weep2nee6shaiquigahw8b',
+      'pods.json': 'AMK9hS0rSbSz7cKjPHcOtk6CGHFjhSHwhbQ3sedK',
+      'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
+      'k8s-resources-windows-cluster.json': '4d08557fd9391b100730f2494bccac68',
+      'k8s-resources-windows-namespace.json': '490b402361724ab1d4c45666c1fa9b6f',
+      'k8s-resources-windows-pod.json': '40597a704a610e936dc6ed374a7ce023',
+      'k8s-windows-cluster-rsrc-use.json': '53a43377ec9aaf2ff64dfc7a1f539334',
+      'k8s-windows-node-rsrc-use.json': '96e7484b0bb53b74fbc2bcb7723cd40b',
+      'k8s-resources-workloads-namespace.json': 'L29WgMrccBDauPs3Xsti3fwaKjMB6fReufWj6Gl1',
+      'k8s-resources-workload.json': 'hZCNbUPfUqjc95N3iumVsaEVHXzaBr3IFKRFvUJf',
+      'apiserver.json': 'eswbt59QCroA3XLdKFvdOHlKB8Iks3h7d2ohstxr',
+      'controller-manager.json': '5g73oHG0pCRz4X1t6gNYouVUv9urrQd4wCdHR2mI',
+      'scheduler.json': '4uMPZ9jmwvYJcM5fcNcNrrt9Sf6ufQL4IKFri2Gp',
+      'proxy.json': 'hhT4orXD1Ott4U1bNNps0R26EHTwMypdcaCjDRPM',
+      'kubelet.json': 'B1azll2ETo7DTiM8CysrH6g4s5NCgkOz6ZdU8Q0j',
+    },
+
+    // Support for Grafana 7.2+ `$__rate_interval` instead of `$__interval`
+    grafana72: true,
+    grafanaIntervalVar: if self.grafana72 then '$__rate_interval' else '$__interval',
+
+    // Config for the Grafana dashboards in the Kubernetes Mixin
+    grafanaK8s: {
+      dashboardNamePrefix: 'Kubernetes / ',
+      dashboardTags: ['kubernetes-mixin'],
+
+      // For links between grafana dashboards, you need to tell us if your grafana
+      // servers under some non-root path.
+      linkPrefix: '.',
+
+      // The default refresh time for all dashboards, default to 10s
+      refresh: '10s',
+      minimumTimeInterval: '1m',
+    },
+
+    // Opt-in to multiCluster dashboards by overriding this and the clusterLabel.
+    showMultiCluster: false,
+    clusterLabel: 'cluster',
+
+    namespaceLabel: 'namespace',
+
+    // This list of filesystem is referenced in various expressions.
+    fstypes: ['ext[234]', 'btrfs', 'xfs', 'zfs'],
+    fstypeSelector: 'fstype=~"%s"' % std.join('|', self.fstypes),
+
+    // This list of disk device names is referenced in various expressions.
+    diskDevices: ['mmcblk.p.+', 'nvme.+', 'rbd.+', 'sd.+', 'vd.+', 'xvd.+', 'dm-.+', 'dasd.+'],
+    diskDeviceSelector: 'device=~"%s"' % std.join('|', self.diskDevices),
+  },
+}

--- a/kube-prometheus/mixin.config
+++ b/kube-prometheus/mixin.config
@@ -1,0 +1,4 @@
+(import 'github.com/kubernetes-monitoring/kubernetes-mixin/alerts/alerts.libsonnet') +
+(import 'github.com/kubernetes-monitoring/kubernetes-mixin/dashboards/dashboards.libsonnet') +
+(import 'github.com/kubernetes-monitoring/kubernetes-mixin/rules/rules.libsonnet') +
+(import 'config.libsonnet')

--- a/remove.sh
+++ b/remove.sh
@@ -10,6 +10,7 @@ kubectl delete -f $DEPLOYDIR/promtail-manifests.yaml
 kubectl delete -f $DEPLOYDIR/tempo-manifests.yaml
 kubectl delete -f $DEPLOYDIR/agent-tempo.yaml
 kubectl delete -f $DEPLOYDIR/grafana-manifests.yaml
+kubectl delete -f $DEPLOYDIR/dashboards/
 kubectl delete -f $DEPLOYDIR/prometheus/
 kubectl delete -f $DEPLOYDIR/prometheus/setup/
 kubectl delete -f $DEPLOYDIR/namespaces.yaml


### PR DESCRIPTION
Add kubernetes-mixin dashboards as config map in default namespace to be imported by grafana deployment using k8s-sidecar. 

Resolves #2 